### PR TITLE
#56 hotfix: main.c parse.c のリークを除去

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -12,5 +12,6 @@ int	main(void)
 		parse(input);
 		free_set((void **)&input, NULL);
 	}
+	free_set((void **)&input, NULL);
 	return (0);
 }

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -30,13 +30,12 @@ void	parse(char *input)
 			g_reserved_funcs[i](&buf[1]);
 		else
 			not_implemented(buf[0]);
-		return ;
 	}
-	i = 0;
-	while (buf[i])
+	else
 	{
-		ft_putendl_fd(buf[i], 1);
-		i++;
+		i = 0;
+		while (buf[i])
+			ft_putendl_fd(buf[i++], 1);
 	}
 	buf = free_string_array(buf);
 }

--- a/tests/issue/12-repeat-test/test.sh
+++ b/tests/issue/12-repeat-test/test.sh
@@ -3,49 +3,64 @@
 cp ./minishell "$(dirname "$0")"
 cd "$(dirname "$0")" || exit
 
+LEAKS=0
+
 # 通常出力
 echo "test" | ./minishell > output
+LEAKS=$(($LEAKS | $?))
 echo "test" > expect
 
 # スペース区切り
 echo "aaa bbb ccc" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo -e 'aaa\nbbb\nccc' >> expect
 
 # echo "echo" | ./minishell >> output
 # echo "echo is not implemented yet" >> expect
 
 echo "cd" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "cd is not implemented yet" >> expect
 
 echo "pwd" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "pwd is not implemented yet" >> expect
 
 echo "export" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "export is not implemented yet" >> expect
 
 echo "unset" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "unset is not implemented yet" >> expect
 
 echo "env" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "env is not implemented yet" >> expect
 
 echo "exit" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "exit is not implemented yet" >> expect
 
 echo "cd cd cd" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "cd is not implemented yet" >> expect
 
 echo " pwd echo" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "pwd is not implemented yet" >> expect
 
 echo "aaa echo" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo -e "aaa\necho" >> expect
 
 echo "" | ./minishell
+LEAKS=$(($LEAKS | $?))
 echo "    " | ./minishell
+LEAKS=$(($LEAKS | $?))
 
 diff output expect
 RES=$?
 rm expect output ./minishell
 cd "$PWD" || exit
-exit $RES
+exit $(($RES | $LEAKS))

--- a/tests/issue/13-echo-test/test.sh
+++ b/tests/issue/13-echo-test/test.sh
@@ -3,32 +3,42 @@
 cp ./minishell "$(dirname "$0")"
 cd "$(dirname "$0")" || exit
 
+LEAKS=0
+
 echo "echo test test pwd echo" | ./minishell > output
+LEAKS=$(($LEAKS | $?))
 echo "echo test test pwd echo" | bash > expect
 
 echo "echo" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo" | bash >> expect
 
 echo "echo aaaa" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo aaaa" | bash >> expect
 
 echo "echo -n" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo -n" | bash >> expect
 
 echo "echo -n test test tset" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo -n test test tset" | bash >> expect
 
 echo "echo a" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo a" | bash >> expect
 
 echo "echo test*ttest" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo test*ttest" | bash >> expect
 
 echo "echo あいう" | ./minishell >> output
+LEAKS=$(($LEAKS | $?))
 echo "echo あいう" | bash >> expect
 
 diff output expect
 RES=$?
 rm expect output ./minishell
 cd "$PWD" || exit
-exit $RES
+exit $(($RES | $LEAKS))


### PR DESCRIPTION
* GNLにEOFを渡した際のfree忘れ
* `not_implemented()`した後のfree忘れ
* テストケースにleakcheckの判定を追加