### PR TITLE
hotfix #73 make debug系でlibdebugを巻き込むように変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ leak		: $(obj) $(lib) $(libdebug)
 	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) ./tests/sharedlib.c -o $(NAME)
 
 debug		: fclean lib_debug
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g"
+	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g" lib="$(lib) $(libdebug)"
 	$(MAKE) clean
 
 sani-debug	: fclean lib_sani-debug
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address"
+	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address" lib="$(lib) $(libdebug)"
 	$(MAKE) clean
 
 norm		:

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -3,6 +3,9 @@
 # include "../libft/libft/libft.h"
 # include "../libft/libex/libex.h"
 # include "../libft/libhash/libhash.h"
+# ifdef DEBUG
+#  include "../libft/libdebug/libdebug.h"
+# endif
 # include "lex.h"
 # include <stdio.h>
 # include <stdbool.h>


### PR DESCRIPTION
close #73 

make debug系のmakeが、test-unitにしか対応できていなかったので、test-Issueにも対応できるようにmakefileを変更しました。