### PR TITLE
Feature readline2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+*
+
+# allowed files
+!Makefile
+!*.c
+!*.h
+
+# allowed dirs
+!srcs/
+!srcs/**/
+!includes/
+!tests
+
+# lib
+!libft/
+!libft/**/
+
+# git / github
+!.github
+!.github/workflows
+!.github/workflows/*.yml
+!.gitignore
+!.editorconfig
+!.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ lib			= $(libft) \
 			$(libex) \
 			$(libhash) \
 
+sharedlib	= ./tests/sharedlib.c
+
 # ****************
 
 libft_dir	= $(lib_dir)/libft
@@ -102,7 +104,7 @@ test_issue	: get_module
 	bash ./tests/all-test.sh ./tests/issue $(TARGET)
 
 leak		: $(obj) $(lib) $(libdebug)
-	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) ./tests/sharedlib.c -o $(NAME) -lreadline
+	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) $(sharedlib) -o $(NAME) -lreadline
 
 debug		: fclean lib_debug
 	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g" lib="$(lib) $(libdebug)"
@@ -117,6 +119,14 @@ norm		:
 	|| (printf "\e[31m%s\n\e[m" "Norm KO!"; exit 1)
 	@printf "\e[32m%s\n\e[m" "Norm OK!"
 
+%/main.c: $(lib) FORCE
+	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(lib) -o $(subst main.c,a.out,$@) -lreadline
+
+%/main.c+leak: $(lib) $(sharedlib)
+	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
+
+%/main.c+sani: $(lib) (libdebug) $(sharedlib)
+	$(CC) $(CFLAGS) -D DEBUG=1 -g -fsanitize=address $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
 
 prepush		: norm test
 
@@ -159,3 +169,5 @@ lib_sani-debug	: fclean
 	$(MAKE) sani-debug -C $(libex_dir)
 	$(MAKE) sani-debug -C $(libhash_dir)
 	$(MAKE) sani-debug -C $(libdebug_dir)
+
+FORCE:


### PR DESCRIPTION
fix #111 

* [ ] （ついで）makedile中で`./tests/sharedlib.c`と書いていた部分を変数化
* [ ] （ついで）.gitignoreを追加
* [ ] #111

```makefile
%/main.c: $(lib) FORCE
	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(lib) -o $(subst main.c,a.out,$@) -lreadline

%/main.c+leak: $(lib) $(sharedlib)
	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline

FORCE:
```

### 使い方
```sh
make Path/TO/YOUR/TEST/main.c
make Path/TO/YOUR/TEST/main.c+leak # leakcheck付き
```

## 解説
```makefile
%/main.c:                            # Path/TO/YOUR/TEST/main.cで動くように
    echo $@
  # $@: ターゲット名の文字列を使う
  
%/main.c: FORCE               # 空のルールを依存関係に持つと必ず動く（Nothing to be done for all 対策）
    $(filter-out ./main.c,$(src:%.c))        # $(src)の中から`./main.c`を除外
    $(subst main.c,a.out,$@)                  # $@の文字列から`main.c`を見つけ、`a.out`に置換（`leaks`をpidでするようにしたので、実行ファイル名を`minishell`にする必要がなく、`./minishell`上書きを避けるために`a.out`に）
```