### PR TITLE
New make rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+*
+
+# allowed files
+!Makefile
+!*.c
+!*.h
+
+# allowed dirs
+!srcs/
+!srcs/**/
+!includes/
+!tests
+
+# lib
+!libft/
+!libft/**/
+
+# git / github
+!.github
+!.github/workflows
+!.github/workflows/*.yml
+!.gitignore
+!.editorconfig
+!.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,12 @@
 			debug \
 			sani-debug \
 			get_module \
+			FORCE \
 
 # ***********************************
 
 NAME		= minishell
-includes	= includes
+includes	= ./includes ./libft/libft ./libft/libex ./libft/libhash ./libft/libdebug
 src_dir		= srcs
 obj_dir		= objs
 obj			= $(src:%.c=$(src_dir)/%.o)
@@ -23,7 +24,8 @@ obj			= $(src:%.c=$(src_dir)/%.o)
 # ***********************************
 
 CC 			= gcc
-CFLAGS		= -Wall -Wextra -Werror -O3 -I$(includes)
+LIBS		= -L./libft/libft -L./libft/libex -L./libft/libhash -L./libft/libdebug -lft -lex -lhash -lreadline
+CFLAGS		= -Wall -Wextra -Werror -O3 -g $(includes:%=-I%)
 
 # ***********************************
 
@@ -71,10 +73,11 @@ libdebug		= $(libdebug_dir)/libdebug.a
 all			: $(NAME)
 
 $(NAME)		: $(obj) $(lib)
-	$(CC) $(CFLAGS) $(obj) $(lib) -o $(NAME) -lreadline
+	$(CC) $(CFLAGS) $(obj) -o $(NAME) $(LIBS)
 
 clean		: lib_clean
 	$(RM) $(obj)
+	/bin/rm -rf $(NAME).dSYM
 
 fclean		: lib_fclean
 	$(RM) $(obj)
@@ -85,7 +88,7 @@ re			: fclean all
 # ***********************************
 
 init		:
-	zsh header.sh $(src_dir) $(includes)/shell.h Makefile $(src_dir)
+	zsh header.sh $(src_dir) includes/shell.h Makefile $(src_dir)
 	zsh header.sh $(libft_dir) $(libft_dir)/libft.h $(libft_dir)/Makefile
 	zsh header.sh $(libex_dir) $(libex_dir)/libex.h $(libex_dir)/Makefile
 	zsh header.sh $(libhash_dir) $(libhash_dir)/libhash.h $(libhash_dir)/Makefile
@@ -106,12 +109,8 @@ test_issue	: get_module
 leak		: $(obj) $(lib) $(libdebug)
 	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) $(sharedlib) -o $(NAME) -lreadline
 
-debug		: fclean lib_debug
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g" lib="$(lib) $(libdebug)"
-	$(MAKE) clean
-
 sani-debug	: fclean lib_sani-debug
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address" lib="$(lib) $(libdebug)"
+	$(MAKE) CFLAGS="$(CFLAGS) -fsanitize=address" lib="$(lib) $(libdebug)"
 	$(MAKE) clean
 
 norm		:
@@ -119,14 +118,14 @@ norm		:
 	|| (printf "\e[31m%s\n\e[m" "Norm KO!"; exit 1)
 	@printf "\e[32m%s\n\e[m" "Norm OK!"
 
-%/main.c: $(lib) FORCE
-	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(lib) -o $(subst main.c,a.out,$@) -lreadline
+tests/%/main.c: $(lib) FORCE
+	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) -o $(subst main.c,a.out,$@) $(LIBS) -ldebug
 
-%/main.c+leak: $(lib) $(sharedlib)
-	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
+tests/%/main.c+leak: $(lib) $(sharedlib)
+	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(sharedlib) -o $(subst main.c+leak,a.out,$@) $(LIBS) -ldebug
 
-%/main.c+sani: $(lib) (libdebug) $(sharedlib)
-	$(CC) $(CFLAGS) -D DEBUG=1 -g -fsanitize=address $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
+tests/%/main.c+sani: $(lib) $(libdebug)
+	$(CC) $(CFLAGS) -fsanitize=address $(subst +sani,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) -o $(subst main.c+sani,a.out,$@) $(LIBS) -ldebug
 
 prepush		: norm test
 
@@ -158,14 +157,8 @@ lib_fclean	:
 	$(MAKE) fclean -C $(libhash_dir)
 	$(MAKE) fclean -C $(libdebug_dir)
 
-lib_debug	:
-	$(MAKE) re -C $(libft_dir)
-	$(MAKE) debug -C $(libex_dir)
-	$(MAKE) debug -C $(libhash_dir)
-	$(MAKE) debug -C $(libdebug_dir)
-
-lib_sani-debug	: fclean
-	$(MAKE) re -C $(libft_dir)
+lib_sani-debug	:
+	$(MAKE) -C $(libft_dir)
 	$(MAKE) sani-debug -C $(libex_dir)
 	$(MAKE) sani-debug -C $(libhash_dir)
 	$(MAKE) sani-debug -C $(libdebug_dir)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ lib			= $(libft) \
 			$(libex) \
 			$(libhash) \
 
+sharedlib	= ./tests/sharedlib.c
+
 # ****************
 
 libft_dir	= $(lib_dir)/libft
@@ -102,7 +104,7 @@ test_issue	: get_module
 	bash ./tests/all-test.sh ./tests/issue $(TARGET)
 
 leak		: $(obj) $(lib) $(libdebug)
-	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) ./tests/sharedlib.c -o $(NAME) -lreadline
+	$(CC) $(CFLAGS) $(obj) $(lib) $(libdebug) $(sharedlib) -o $(NAME) -lreadline
 
 debug		: fclean lib_debug
 	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g" lib="$(lib) $(libdebug)"
@@ -117,6 +119,14 @@ norm		:
 	|| (printf "\e[31m%s\n\e[m" "Norm KO!"; exit 1)
 	@printf "\e[32m%s\n\e[m" "Norm OK!"
 
+%/main.c: $(lib) FORCE
+	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(lib) -o $(subst main.c,a.out,$@) -lreadline
+
+%/main.c+leak: $(lib) $(sharedlib)
+	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
+
+%/main.c+sani: $(lib) (libdebug) $(sharedlib)
+	$(CC) $(CFLAGS) -D DEBUG=1 -g -fsanitize=address $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline
 
 prepush		: norm test
 
@@ -159,3 +169,5 @@ lib_sani-debug	: fclean
 	$(MAKE) sani-debug -C $(libex_dir)
 	$(MAKE) sani-debug -C $(libhash_dir)
 	$(MAKE) sani-debug -C $(libdebug_dir)
+
+FORCE:

--- a/includes/lex.h
+++ b/includes/lex.h
@@ -3,17 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   lex.h                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ywake <ywake@student.42tokyo.jp>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:06:12 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/09 16:06:13 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/18 17:36:17 by ywake            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef LEX_H
 # define LEX_H
 
-# include "../libft/libft/libft.h"
+# include "libft.h"
 # define PAD 256
 
 typedef enum e_token_type

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -3,20 +3,20 @@
 /*                                                        :::      ::::::::   */
 /*   shell.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: ywake <ywake@student.42tokyo.jp>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:06:15 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/09 16:06:15 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/18 17:39:39 by ywake            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef SHELL_H
 # define SHELL_H
-# include "../libft/libft/libft.h"
-# include "../libft/libex/libex.h"
-# include "../libft/libhash/libhash.h"
+# include "libft.h"
+# include "libex.h"
+# include "libhash.h"
 # ifdef DEBUG
-#  include "../libft/libdebug/libdebug.h"
+#  include "libdebug.h"
 # endif
 # define PROMPT "minishell> "
 # define QUOTE_PROMPT "quote... "

--- a/libft/libdebug/Makefile
+++ b/libft/libdebug/Makefile
@@ -2,7 +2,7 @@
 
 NAME	= libdebug.a
 CC		= gcc
-CFLAGS	= -Wall -Wextra -Werror -O3
+CFLAGS	= -Wall -Wextra -Werror -O3 -g
 obj		= $(src:%.c=%.o)
 
 .PHONY: all clean fclean re debug sani-debug
@@ -32,8 +32,5 @@ re: fclean all
 
 # ***********************************
 
-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g"
-
 sani-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address"
+	$(MAKE) CFLAGS="$(CFLAGS) -fsanitize=address"

--- a/libft/libex/Makefile
+++ b/libft/libex/Makefile
@@ -2,7 +2,7 @@
 
 NAME	= libex.a
 CC		= gcc
-CFLAGS	= -Wall -Wextra -Werror -O3
+CFLAGS	= -Wall -Wextra -Werror -O3 -g
 obj		= $(src:%.c=%.o)
 
 .PHONY: all clean fclean re debug sani-debug
@@ -45,8 +45,5 @@ re: fclean all
 
 # ***********************************
 
-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g"
-
 sani-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address"
+	$(MAKE) CFLAGS="$(CFLAGS) -fsanitize=address"

--- a/libft/libft/Makefile
+++ b/libft/libft/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Werror -O3
+CFLAGS = -Wall -Wextra -Werror -O3 -g
 NAME = libft.a
 
 src =\

--- a/libft/libhash/Makefile
+++ b/libft/libhash/Makefile
@@ -2,7 +2,7 @@
 
 NAME	= libhash.a
 CC		= gcc
-CFLAGS	= -Wall -Wextra -Werror -O3
+CFLAGS	= -Wall -Wextra -Werror -O3 -g
 obj		= $(src:%.c=%.o)
 
 .PHONY: all clean fclean re debug sani-debug
@@ -42,8 +42,5 @@ re: fclean all
 
 # ***********************************
 
-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g"
-
 sani-debug: fclean
-	$(MAKE) CFLAGS="$(CFLAGS) -D DEBUG=1 -g -fsanitize=address"
+	$(MAKE) CFLAGS="$(CFLAGS) -fsanitize=address"


### PR DESCRIPTION
fix #111 

* [ ] （ついで）makedile中で`./tests/sharedlib.c`と書いていた部分を変数化
* [ ] （ついで）.gitignoreを追加
* [x] #111

```makefile
%/main.c: $(lib) FORCE
	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $(lib) -o $(subst main.c,a.out,$@) -lreadline

%/main.c+leak: $(lib) $(sharedlib)
	$(CC) $(CFLAGS) $(subst +leak,,$@) $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) $^ -o $(subst main.c+leak,a.out,$@) -lreadline

FORCE:
```

### 使い方
```sh
make Path/TO/YOUR/TEST/main.c
make Path/TO/YOUR/TEST/main.c+leak # leakcheck付き
```

## 解説
```makefile
%/main.c:                            # Path/TO/YOUR/TEST/main.cで動くように
    echo $@
  # $@: ターゲット名の文字列を使う
  
%/main.c: FORCE               # 空のルールを依存関係に持つと必ず動く（Nothing to be done for all 対策）
    $(filter-out ./main.c,$(src:%.c))        # $(src)の中から`./main.c`を除外
    $(subst main.c,a.out,$@)                  # $@の文字列から`main.c`を見つけ、`a.out`に置換（`leaks`をpidでするようにしたので、実行ファイル名を`minishell`にする必要がなく、`./minishell`上書きを避けるために`a.out`に）
```