### PR TITLE
Update: make norm を見やすい表示に変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,11 @@ sani-debug	: fclean lib_sani-debug
 	$(MAKE) CFLAGS="$(CFLAGS) -fsanitize=address" $(lib)
 	$(MAKE) clean
 
-norm		:
-	norminette $(src_dir) $(includes) ./libft \
-	|| (printf "\e[31m%s\n\e[m" "Norm KO!"; exit 1)
-	@printf "\e[32m%s\n\e[m" "Norm OK!"
+norm:
+	@printf "\e[31m"; norminette $(src_dir) $(includes) ./libft \
+	| grep -v -e ": OK!" -v -e "Missing or invalid header. Header are being reintroduced as a mandatory part of your files. This is not yet an error." \
+	&& exit 1 \
+	|| printf "\e[32m%s\n\e[m" "Norm OK!"; printf "\e[m"
 
 tests/%/main.c: $(lib) FORCE
 	$(CC) $(CFLAGS) $@ $(filter-out srcs/./main.c,$(src:%.c=$(src_dir)/%.c)) -o $(subst main.c,a.out,$@) $(LIBS)


### PR DESCRIPTION
## 概要

* make normを見やすい表示に変更

## やったこと詳細
変更した関数 | 問題 | 変更
-|-|-
Makefile/norm | エラーがあった時、それがどこか見ずらい | ノームエラーのない行は表示しない
 .. | .. | "Missing or invalid header"もうざいので表示しない
 .. | .. | エラーがあったら赤で表示してエラー終了

### ほぼ作り直しなので処理の流れ
norm→grepで出力があったときはエラーとして表示してエラー終了。なかったときは"OK"表示して正常終了。

### 補足
* grepの終了ステータスは出力があったら`0`、なかったら`1`
* `$? == 0`の時は`&&`に行き、`$? != 0`のときは`||`に行く

## やらないこと（あれば）


## 動作確認・テスト

```
make norm
```

## その他

