### PR TITLE
Parser

### DIFF
--- a/includes/astree.h
+++ b/includes/astree.h
@@ -3,16 +3,16 @@
 
 typedef enum e_node_type
 {
-	NODE_PIPE 			= (1 << 0),
-	NODE_BCKGRND 		= (1 << 1),
-	NODE_SEQ 			= (1 << 2),
+	NODE_PIPE			= (1 << 0),
+	NODE_BCKGRND		= (1 << 1),
+	NODE_SEQ			= (1 << 2),
 	NODE_REDIRECT_IN	= (1 << 3),
 	NODE_REDIRECT_OUT	= (1 << 4),
 	NODE_REDIRECT_IN2	= (1 << 5),
 	NODE_REDIRECT_OUT2	= (1 << 6),
 	NODE_CMDPATH		= (1 << 7),
 	NODE_ARGUMENT		= (1 << 8),
-	NODE_DATA 			= (1 << 9),
+	NODE_DATA			= (1 << 9),
 	NODE_REDIRECT_LIST	= (1 << 10),
 	NODE_REDIRECTION	= (1 << 11),
 }	t_node_type;

--- a/includes/astree.h
+++ b/includes/astree.h
@@ -1,6 +1,6 @@
 #ifndef ASTREE_H
 # define ASTREE_H
-# include "shell.h"
+
 typedef enum e_node_type
 {
 	NODE_PIPE 			= (1 << 0),

--- a/includes/astree.h
+++ b/includes/astree.h
@@ -13,6 +13,8 @@ typedef enum e_node_type
 	NODE_CMDPATH		= (1 << 7),
 	NODE_ARGUMENT		= (1 << 8),
 	NODE_DATA 			= (1 << 9),
+	NODE_REDIRECT_LIST	= (1 << 10),
+	NODE_REDIRECTION	= (1 << 11),
 }	t_node_type;
 
 /*
@@ -29,5 +31,6 @@ typedef struct s_astree
 t_astree	*astree_create_node(
 				t_node_type type, char *data, t_astree *left, t_astree *right);
 t_astree	*astree_delete_node(t_astree *node);
+t_astree	*astree_get_right_last(t_astree *node);
 
 #endif

--- a/includes/astree.h
+++ b/includes/astree.h
@@ -1,0 +1,33 @@
+#ifndef ASTREE_H
+# define ASTREE_H
+# include "shell.h"
+typedef enum e_node_type
+{
+	NODE_PIPE 			= (1 << 0),
+	NODE_BCKGRND 		= (1 << 1),
+	NODE_SEQ 			= (1 << 2),
+	NODE_REDIRECT_IN	= (1 << 3),
+	NODE_REDIRECT_OUT	= (1 << 4),
+	NODE_REDIRECT_IN2	= (1 << 5),
+	NODE_REDIRECT_OUT2	= (1 << 6),
+	NODE_CMDPATH		= (1 << 7),
+	NODE_ARGUMENT		= (1 << 8),
+	NODE_DATA 			= (1 << 9),
+}	t_node_type;
+
+/*
+** Deliverables of parse.
+*/
+typedef struct s_astree
+{
+	t_node_type		type;
+	char			*data;
+	struct s_astree	*left;
+	struct s_astree	*right;
+}	t_astree;
+
+t_astree	*astree_create_node(
+				t_node_type type, char *data, t_astree *left, t_astree *right);
+t_astree	*astree_delete_node(t_astree *node);
+
+#endif

--- a/includes/logging.h
+++ b/includes/logging.h
@@ -1,0 +1,15 @@
+#ifndef LOGGING_H
+# define LOGGING_H
+
+# define END			"\033[0m"
+# define BOLD			"\033[1m"
+# define BLACK			"\033[30m"
+# define RED			"\033[31m"
+# define GREEN			"\033[32m"
+# define YELLOW			"\033[33m"
+# define BLUE			"\033[34m"
+# define MAGENTA		"\033[35m"
+# define CYAN			"\033[36m"
+# define WHITE			"\033[37m"
+
+#endif

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -4,7 +4,8 @@
 # include "astree.h"
 # include "lex.h"
 
-bool		is_tokentype(t_token_type type, t_list **current, char **buf_ptr);
+bool		is_tokentype_and_store_data(
+				t_token_type type, t_list **current, char **buf_ptr);
 t_astree	*cmdline(t_list **toks);
 t_astree	*job(t_list **toks);
 t_astree	*cmd(t_list **toks);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -4,7 +4,7 @@
 # include "astree.h"
 # include "lex.h"
 
-bool		is_tokentype(t_token_type type, t_list **current);
+bool		move_if_is_tokentype(t_token_type type, t_list **current);
 bool		allocate_data_if_is_token(t_list **current, char **buf_ptr);
 t_astree	*cmdline(t_list **toks);
 t_astree	*job(t_list **toks);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -8,6 +8,8 @@ bool		is_tokentype(t_token_type type, t_list **current, char **buf_ptr);
 t_astree	*cmdline(t_list **toks);
 t_astree	*job(t_list **toks);
 t_astree	*cmd(t_list **toks);
+t_astree	*redirlist(t_list **toks);
+t_astree	*redirection(t_list **toks);
 t_astree	*simplecmd(t_list **toks);
 t_astree	*tokenlist(t_list **toks);
 

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -4,7 +4,7 @@
 # include "astree.h"
 # include "lex.h"
 
-bool		is_tokentype(t_token_type type, t_list **current);
+bool		is_tokentype(t_token_type type, t_list **current, char **buf_ptr);
 t_astree	*cmdline(t_list **toks);
 t_astree	*job(t_list **toks);
 t_astree	*cmd(t_list **toks);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -1,7 +1,8 @@
 #ifndef PARSE_H
 # define PARSE_H
-# include "shell.h"
+# include "libft.h"
 # include "astree.h"
+# include "lex.h"
 
 bool		is_tokentype(t_token_type type, t_list **current);
 t_astree	*cmdline(t_list **toks);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -4,8 +4,8 @@
 # include "astree.h"
 # include "lex.h"
 
-bool		is_tokentype_and_store_data(
-				t_token_type type, t_list **current, char **buf_ptr);
+bool		is_tokentype(t_token_type type, t_list **current);
+bool		allocate_data_if_is_token(t_list **current, char **buf_ptr);
 t_astree	*cmdline(t_list **toks);
 t_astree	*job(t_list **toks);
 t_astree	*cmd(t_list **toks);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -1,0 +1,13 @@
+#ifndef PARSE_H
+# define PARSE_H
+# include "shell.h"
+# include "astree.h"
+
+bool		is_tokentype(t_token_type type, t_list **current);
+t_astree	*cmdline(t_list **toks);
+t_astree	*job(t_list **toks);
+t_astree	*cmd(t_list **toks);
+t_astree	*simplecmd(t_list **toks);
+t_astree	*tokenlist(t_list **toks);
+
+#endif

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -8,6 +8,7 @@
 # define DQUOTE_PROMPT "dquote... "
 # define HEREDOC_PROMPT "heredoc... "
 # include "lex.h"
+# include "astree.h"
 # include <stdio.h>
 # include <stdbool.h>
 # include <readline/readline.h>
@@ -31,5 +32,6 @@ int				ft_env(char **args);
 int				ft_export(char **args);
 int				ft_unset(char **args);
 int				ft_pwd(char **args);
+bool			parse_v2(t_lexer *lex, t_astree **res_buf);
 
 #endif

--- a/srcs/parse/astree.c
+++ b/srcs/parse/astree.c
@@ -1,6 +1,5 @@
 #include "astree.h"
-#include <stdlib.h>
-#include "libft.h"
+#include "libex.h"
 
 t_astree	*astree_create_node(
 				t_node_type type, char *data, t_astree *left, t_astree *right)

--- a/srcs/parse/astree.c
+++ b/srcs/parse/astree.c
@@ -1,6 +1,6 @@
 #include "astree.h"
-# include <stdlib.h>
-# include "libft.h"
+#include <stdlib.h>
+#include "libft.h"
 
 t_astree	*astree_create_node(
 				t_node_type type, char *data, t_astree *left, t_astree *right)

--- a/srcs/parse/astree.c
+++ b/srcs/parse/astree.c
@@ -15,12 +15,24 @@ t_astree	*astree_create_node(
 	return (res);
 }
 
+/**
+ * @brief delete node.
+ * @return always NULL.
+ */
 t_astree	*astree_delete_node(t_astree *node)
 {
 	if (node == NULL)
 		return (NULL);
 	node->left = astree_delete_node(node->left);
 	node->right = astree_delete_node(node->right);
+	free(node->data);
 	free(node);
 	return (NULL);
+}
+
+t_astree	*astree_get_right_last(t_astree *node)
+{
+	while (node->right != NULL)
+		node = node->right;
+	return (node);
 }

--- a/srcs/parse/astree.c
+++ b/srcs/parse/astree.c
@@ -1,0 +1,24 @@
+#include "astree.h"
+
+t_astree	*astree_create_node(
+				t_node_type type, char *data, t_astree *left, t_astree *right)
+{
+	t_astree	*res;
+
+	res = ft_xmalloc(sizeof(t_astree));
+	res->type = type;
+	res->data = data;
+	res->left = left;
+	res->right = right;
+	return (res);
+}
+
+t_astree	*astree_delete_node(t_astree *node)
+{
+	if (node == NULL)
+		return (NULL);
+	node->left = astree_delete_node(node->left);
+	node->right = astree_delete_node(node->right);
+	free(node);
+	return (NULL);
+}

--- a/srcs/parse/astree.c
+++ b/srcs/parse/astree.c
@@ -1,4 +1,6 @@
 #include "astree.h"
+# include <stdlib.h>
+# include "libft.h"
 
 t_astree	*astree_create_node(
 				t_node_type type, char *data, t_astree *left, t_astree *right)

--- a/srcs/parse/command.c
+++ b/srcs/parse/command.c
@@ -1,14 +1,12 @@
 #include "parse.h"
 
-t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n);
-t_astree	*cmd1(t_list **toks); // <simple command>
+t_astree	*cmd1(t_list **toks); // <simple command> <redirection list>
+t_astree	*cmd2(t_list **toks); // <simple command>
+void		collect_args(t_astree *simplecmd_node, t_astree *redirlist_node);
 
 /**
- * <command>	::= <simple command> '<' <filename>
- *				  | <simple command> '>' <filename>
- *				  | <simple command> '<<' <filename>
- *				  | <simple command> '>>' <filename>
- *				  | <simple command>
+ * @brief <command>	::= <simple command> <redirection list>
+ *					  | <simple command>
  */
 t_astree	*cmd(t_list **toks)
 {
@@ -16,48 +14,50 @@ t_astree	*cmd(t_list **toks)
 	t_astree	*result;
 
 	save = *toks;
-	result = cmd_redirect(toks, CHAR_LESSER, NODE_REDIRECT_IN);
+	result = cmd1(toks);
 	if (result != NULL)
 		return (result);
 	*toks = save;
-	result = cmd_redirect(toks, CHAR_GREATER, NODE_REDIRECT_OUT);
-	if (result != NULL)
-		return (result);
-	*toks = save;
-	result = cmd_redirect(toks, CHAR_LESSER2, NODE_REDIRECT_IN2);
-	if (result != NULL)
-		return (result);
-	*toks = save;
-	result = cmd_redirect(toks, CHAR_GREATER2, NODE_REDIRECT_OUT2);
-	if (result != NULL)
-		return (result);
-	*toks = save;
-	return (cmd1(toks));
+	return (cmd2(toks));
 }
 
 /**
- * <command> ::= <simple command> t <filename>
+ * <command> ::= <simple command> <redirection list>
  */
-t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n)
+t_astree	*cmd1(t_list **toks)
 {
 	t_astree	*simplecmd_node;
+	t_astree	*redirlist_node;
 	t_astree	*result;
-	char		*filename;
 
 	simplecmd_node = simplecmd(toks);
 	if (simplecmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(t, toks, NULL))
+	redirlist_node = redirlist(toks);
+	if (redirlist_node == NULL)
 		return (astree_delete_node(simplecmd_node));
-	if (!is_tokentype(TOKEN, toks, &filename))
-		return (astree_delete_node(simplecmd_node));
-	return (astree_create_node(n | NODE_DATA, filename, NULL, simplecmd_node));
+	collect_args(simplecmd_node, redirlist_node);
+	return (astree_create_node(NODE_REDIRECTION, NULL,
+			simplecmd_node, redirlist_node));
 }
 
 /**
  * <command> ::= <simple command>
  */
-t_astree	*cmd1(t_list **toks)
+t_astree	*cmd2(t_list **toks)
 {
 	return (simplecmd(toks));
+}
+
+void	collect_args(t_astree *simplecmd_node, t_astree *redirlist_node)
+{
+	t_astree	*args;
+
+	while (redirlist_node != NULL)
+	{
+		args = redirlist_node->left->right;
+		astree_get_right_last(simplecmd_node)->right = args;
+		redirlist_node->left->right = NULL;
+		redirlist_node = redirlist_node->right;
+	}
 }

--- a/srcs/parse/command.c
+++ b/srcs/parse/command.c
@@ -47,14 +47,11 @@ t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n)
 	simplecmd_node = simplecmd(toks);
 	if (simplecmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(t, toks))
-		return (astree_delete_node(simplecmd_node));
-	filename = ft_strdup(((t_tok *)(*toks)->content)->data);
-	if (!is_tokentype(TOKEN, toks))
-	{
-		free(filename);
+	if (!is_tokentype(t, toks, NULL)) {
 		return (astree_delete_node(simplecmd_node));
 	}
+	if (!is_tokentype(TOKEN, toks, &filename))
+		return (astree_delete_node(simplecmd_node));
 	return (astree_create_node(n | NODE_DATA, filename, NULL, simplecmd_node));
 }
 

--- a/srcs/parse/command.c
+++ b/srcs/parse/command.c
@@ -1,0 +1,67 @@
+#include "parse.h"
+
+t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n);
+t_astree	*cmd1(t_list **toks); // <simple command>
+
+/**
+ * <command>	::= <simple command> '<' <filename>
+ *				  | <simple command> '>' <filename>
+ *				  | <simple command> '<<' <filename>
+ *				  | <simple command> '>>' <filename>
+ *				  | <simple command>
+ */
+t_astree	*cmd(t_list **toks)
+{
+	t_list		*save;
+	t_astree	*result;
+
+	save = *toks;
+	result = cmd_redirect(toks, CHAR_LESSER, NODE_REDIRECT_IN);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = cmd_redirect(toks, CHAR_GREATER, NODE_REDIRECT_OUT);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = cmd_redirect(toks, CHAR_LESSER2, NODE_REDIRECT_IN2);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = cmd_redirect(toks, CHAR_GREATER2, NODE_REDIRECT_OUT2);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	return (cmd1(toks));
+}
+
+/**
+ * <command> ::= <simple command> t <filename>
+ */
+t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n)
+{
+	t_astree	*simplecmd_node;
+	t_astree	*result;
+	char		*filename;
+
+	simplecmd_node = simplecmd(toks);
+	if (simplecmd_node == NULL)
+		return (NULL);
+	if (!is_tokentype(t, toks))
+		return (astree_delete_node(simplecmd_node));
+	filename = ft_strdup(((t_tok *)(*toks)->content)->data);
+	if (!is_tokentype(TOKEN, toks))
+	{
+		free(filename);
+		return (astree_delete_node(simplecmd_node));
+	}
+	return (astree_create_node(n | NODE_DATA, filename, NULL, simplecmd_node));
+}
+
+/**
+ * <command> ::= <simple command>
+ */
+t_astree	*cmd1(t_list **toks)
+{
+	return (simplecmd(toks));
+}

--- a/srcs/parse/command.c
+++ b/srcs/parse/command.c
@@ -47,9 +47,8 @@ t_astree	*cmd_redirect(t_list **toks, t_token_type t, t_node_type n)
 	simplecmd_node = simplecmd(toks);
 	if (simplecmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(t, toks, NULL)) {
+	if (!is_tokentype(t, toks, NULL))
 		return (astree_delete_node(simplecmd_node));
-	}
 	if (!is_tokentype(TOKEN, toks, &filename))
 		return (astree_delete_node(simplecmd_node));
 	return (astree_create_node(n | NODE_DATA, filename, NULL, simplecmd_node));

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -38,7 +38,7 @@ t_astree	*cmdline1(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks))
+	if (!move_if_is_tokentype(CHAR_SEMICOLON, toks))
 		return (astree_delete_node(job_node));
 	cmdline_node = cmdline(toks);
 	if (cmdline_node == NULL)
@@ -57,7 +57,7 @@ t_astree	*cmdline2(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks))
+	if (!move_if_is_tokentype(CHAR_SEMICOLON, toks))
 		return (astree_delete_node(job_node));
 	return (astree_create_node(NODE_SEQ, NULL, job_node, NULL));
 }

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -38,7 +38,7 @@ t_astree	*cmdline1(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks, NULL))
+	if (!is_tokentype_and_store_data(CHAR_SEMICOLON, toks, NULL))
 		return (astree_delete_node(job_node));
 	cmdline_node = cmdline(toks);
 	if (cmdline_node == NULL)
@@ -57,7 +57,7 @@ t_astree	*cmdline2(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks, NULL))
+	if (!is_tokentype_and_store_data(CHAR_SEMICOLON, toks, NULL))
 		return (astree_delete_node(job_node));
 	return (astree_create_node(NODE_SEQ, NULL, job_node, NULL));
 }

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -38,7 +38,7 @@ t_astree	*cmdline1(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype_and_store_data(CHAR_SEMICOLON, toks, NULL))
+	if (!is_tokentype(CHAR_SEMICOLON, toks))
 		return (astree_delete_node(job_node));
 	cmdline_node = cmdline(toks);
 	if (cmdline_node == NULL)
@@ -57,7 +57,7 @@ t_astree	*cmdline2(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype_and_store_data(CHAR_SEMICOLON, toks, NULL))
+	if (!is_tokentype(CHAR_SEMICOLON, toks))
 		return (astree_delete_node(job_node));
 	return (astree_create_node(NODE_SEQ, NULL, job_node, NULL));
 }

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -1,0 +1,72 @@
+#include "parse.h"
+
+t_astree	*cmdline1(t_list **toks); // <job> ';' <command line>
+t_astree	*cmdline2(t_list **toks); // <job> ';'
+t_astree	*cmdline3(t_list **toks); // <job>
+
+/*
+** <command line>	::= <job> ';' <command line>
+**					  | <job> ';'
+**					  | <job> '&' <command line>	// not make
+**					  | <job> '&'					// not make
+**					  | <job>
+*/
+t_astree	*cmdline(t_list **toks)
+{
+	t_list		*save;
+	t_astree	*result;
+
+	save = *toks;
+	result = cmdline1(toks);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = cmdline2(toks);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	return (cmdline3(toks));
+}
+
+/*
+** @brief <command line> ::= <job> ';' <command line>
+*/
+t_astree	*cmdline1(t_list **toks)
+{
+	t_astree	*job_node;
+	t_astree	*cmdline_node;
+
+	job_node = job(toks);
+	if (job_node == NULL)
+		return (NULL);
+	if (!is_tokentype(CHAR_SEMICOLON, toks))
+		return (astree_delete_node(job_node));
+	cmdline_node = cmdline(toks);
+	if (cmdline_node == NULL)
+		return (astree_delete_node(job_node));
+	return (astree_create_node(NODE_SEQ, NULL, job_node, cmdline_node));
+}
+
+/*
+** @brief <command line> ::= <job> ';'
+*/
+t_astree	*cmdline2(t_list **toks)
+{
+	t_astree	*job_node;
+	t_astree	*result;
+
+	job_node = job(toks);
+	if (job_node == NULL)
+		return (NULL);
+	if (!is_tokentype(CHAR_SEMICOLON, toks))
+		return (astree_delete_node(job_node));
+	return (astree_create_node(NODE_SEQ, NULL, job_node, NULL));
+}
+
+/*
+** @brief <command line> ::= <job>
+*/
+t_astree	*cmdline3(t_list **toks)
+{
+	return (job(toks));
+}

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -1,5 +1,4 @@
 #include "parse.h"
-
 t_astree	*cmdline1(t_list **toks); // <job> ';' <command line>
 t_astree	*cmdline2(t_list **toks); // <job> ';'
 t_astree	*cmdline3(t_list **toks); // <job>
@@ -39,7 +38,7 @@ t_astree	*cmdline1(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks))
+	if (!is_tokentype(CHAR_SEMICOLON, toks, NULL))
 		return (astree_delete_node(job_node));
 	cmdline_node = cmdline(toks);
 	if (cmdline_node == NULL)
@@ -58,7 +57,7 @@ t_astree	*cmdline2(t_list **toks)
 	job_node = job(toks);
 	if (job_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_SEMICOLON, toks))
+	if (!is_tokentype(CHAR_SEMICOLON, toks, NULL))
 		return (astree_delete_node(job_node));
 	return (astree_create_node(NODE_SEQ, NULL, job_node, NULL));
 }

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -31,7 +31,7 @@ t_astree	*job1(t_list **toks)
 	cmd_node = cmd(toks);
 	if (cmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype_and_store_data(CHAR_PIPE, toks, NULL))
+	if (!is_tokentype(CHAR_PIPE, toks))
 		return (astree_delete_node(cmd_node));
 	job_node = job(toks);
 	if (job_node == NULL)

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -31,7 +31,7 @@ t_astree	*job1(t_list **toks)
 	cmd_node = cmd(toks);
 	if (cmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_PIPE, toks))
+	if (!move_if_is_tokentype(CHAR_PIPE, toks))
 		return (astree_delete_node(cmd_node));
 	job_node = job(toks);
 	if (job_node == NULL)

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -27,12 +27,11 @@ t_astree	*job1(t_list **toks)
 {
 	t_astree	*cmd_node;
 	t_astree	*job_node;
-	t_astree	*result;
 
 	cmd_node = cmd(toks);
 	if (cmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_PIPE, toks))
+	if (!is_tokentype(CHAR_PIPE, toks, NULL))
 		return (astree_delete_node(cmd_node));
 	job_node = job(toks);
 	if (job_node == NULL)

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -31,7 +31,7 @@ t_astree	*job1(t_list **toks)
 	cmd_node = cmd(toks);
 	if (cmd_node == NULL)
 		return (NULL);
-	if (!is_tokentype(CHAR_PIPE, toks, NULL))
+	if (!is_tokentype_and_store_data(CHAR_PIPE, toks, NULL))
 		return (astree_delete_node(cmd_node));
 	job_node = job(toks);
 	if (job_node == NULL)

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -1,0 +1,49 @@
+#include "parse.h"
+
+t_astree	*job1(t_list **toks); // <command> '|' <job>
+t_astree	*job2(t_list **toks); // <command>
+
+/*
+** <job>			::= <command> '|' <job>
+**					  | <command>
+*/
+t_astree	*job(t_list **toks)
+{
+	t_list		*save;
+	t_astree	*result;
+
+	save = *toks;
+	result = job1(toks);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	return (job2(toks));
+}
+
+/*
+** @brief <job> ::= <command> '|' <job>
+*/
+t_astree	*job1(t_list **toks)
+{
+	t_astree	*cmd_node;
+	t_astree	*job_node;
+	t_astree	*result;
+
+	cmd_node = cmd(toks);
+	if (cmd_node == NULL)
+		return (NULL);
+	if (!is_tokentype(CHAR_PIPE, toks))
+		return (astree_delete_node(cmd_node));
+	job_node = job(toks);
+	if (job_node == NULL)
+		return (astree_delete_node(cmd_node));
+	return (astree_create_node(NODE_PIPE, NULL, cmd_node, job_node));
+}
+
+/*
+** @brief <job> ::= <command>
+*/
+t_astree	*job2(t_list **toks)
+{
+	return (cmd(toks));
+}

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,15 +1,25 @@
 #include "shell.h"
 #include "parse.h"
 
-bool	is_tokentype_and_store_data(
-			t_token_type type, t_list **current, char **buf_ptr)
+bool	is_tokentype(t_token_type type, t_list **current)
 {
 	if (*current == NULL)
 		return (false);
 	if (((t_tok *)(*current)->content)->type == type)
 	{
-		if (buf_ptr != NULL)
-			*buf_ptr = ft_xstrdup(((t_tok *)(*current)->content)->data);
+		*current = (*current)->next;
+		return (true);
+	}
+	return (false);
+}
+
+bool	allocate_data_if_is_token(t_list **current, char **buf_ptr)
+{
+	if (*current == NULL)
+		return (false);
+	if (((t_tok *)(*current)->content)->type == TOKEN)
+	{
+		*buf_ptr = ft_xstrdup(((t_tok *)(*current)->content)->data);
 		*current = (*current)->next;
 		return (true);
 	}

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,5 +1,6 @@
 #include "shell.h"
 #include "parse.h"
+#include "logging.h"
 
 bool	is_tokentype(t_token_type type, t_list **current, char **buf_ptr)
 {
@@ -43,14 +44,16 @@ bool	is_tokentype(t_token_type type, t_list **current, char **buf_ptr)
 */
 bool	parse_v2(t_lexer *lex, t_astree **res_buf)
 {
+	t_list	*tokens;
+
 	if (lex == NULL || lex->len == 0 || res_buf == NULL)
 		return (false);
-	*res_buf = cmdline(&lex->listtok);
-	if (lex->listtok != NULL
-		&& ((t_tok *)lex->listtok->content)->type != CHAR_NULL)
+	tokens = lex->listtok;
+	*res_buf = cmdline(&tokens);
+	if (tokens != NULL && ((t_tok *)tokens->content)->type != CHAR_NULL)
 	{
 		ft_putstr_fd("Syntax Error near unexpected token `", 2);
-		ft_putstr_fd(((t_tok *)lex->listtok->content)->data, 2);
+		ft_putstr_fd(((t_tok *)tokens->content)->data, 2);
 		ft_putendl_fd("'", 2);
 		return (false);
 	}

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,7 +1,7 @@
 #include "shell.h"
 #include "parse.h"
 
-bool	is_tokentype(t_token_type type, t_list **current)
+bool	move_if_is_tokentype(t_token_type type, t_list **current)
 {
 	if (*current == NULL)
 		return (false);

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,0 +1,28 @@
+#include "shell.h"
+#include "parse.h"
+
+bool	is_tokentype(t_token_type type, t_list **current)
+{
+	if (((t_tok *)(*current)->content)->type == type)
+	{
+		*current = (*current)->next;
+		return (true);
+	}
+	return (false);
+}
+
+bool	parse_v2(t_lexer *lex, t_astree **res_buf)
+{
+	if (lex == NULL || lex->len == 0 || res_buf == NULL)
+		return (false);
+	*res_buf = cmdline(&lex->listtok);
+	if (lex->listtok != NULL
+		&& ((t_tok *)lex->listtok->content)->type != CHAR_NULL)
+	{
+		ft_putstr_fd("Syntax Error near unexpected token `", 2);
+		ft_putstr_fd(((t_tok *)lex->listtok->content)->data, 2);
+		ft_putendl_fd("'", 2);
+		return (false);
+	}
+	return (true);
+}

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -8,13 +8,39 @@ bool	is_tokentype(t_token_type type, t_list **current, char **buf_ptr)
 	if (((t_tok *)(*current)->content)->type == type)
 	{
 		if (buf_ptr != NULL)
-			*buf_ptr = ft_strdup(((t_tok *)(*current)->content)->data);
+			*buf_ptr = ft_xstrdup(((t_tok *)(*current)->content)->data);
 		*current = (*current)->next;
 		return (true);
 	}
 	return (false);
 }
 
+/**
+<command line>		::= <job> ';' <command line>
+					  | <job> ';'
+					  | <job> '&' <command line>	// not make
+					  | <job> '&'					// not make
+					  | <job>
+
+<job>				::= <command> '|' <job>
+					  | <command>
+
+<command>			::= <simple command> <redirection list>
+					  | <simple command>
+
+<redirection list>	::= <redirection> <redirection list>
+
+<redirection>		::= '<' <filename> <token list>
+					  | '>' <filename> <token list>
+					  | '<<' <filename> <token list>
+					  | '>>' <filename> <token list>
+// <token list> will be added after the arg of the previous <simple command>.
+
+<simple command>	::= <pathname> <token list>
+
+<token list>		::= <token> <token list>
+					  | (EMPTY)
+*/
 bool	parse_v2(t_lexer *lex, t_astree **res_buf)
 {
 	if (lex == NULL || lex->len == 0 || res_buf == NULL)

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -46,7 +46,7 @@ bool	parse_v2(t_lexer *lex, t_astree **res_buf)
 {
 	t_list	*tokens;
 
-	if (lex == NULL || lex->len == 0 || res_buf == NULL)
+	if (res_buf == NULL)
 		return (false);
 	tokens = lex->listtok;
 	*res_buf = cmdline(&tokens);

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -52,7 +52,7 @@ bool	parse_v2(t_lexer *lex, t_astree **res_buf)
 	*res_buf = cmdline(&tokens);
 	if (tokens != NULL && ((t_tok *)tokens->content)->type != CHAR_NULL)
 	{
-		ft_putstr_fd("Syntax Error near unexpected token `", 2);
+		ft_putstr_fd("syntax error near unexpected token `", 2);
 		ft_putstr_fd(((t_tok *)tokens->content)->data, 2);
 		ft_putendl_fd("'", 2);
 		return (false);

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,10 +1,14 @@
 #include "shell.h"
 #include "parse.h"
 
-bool	is_tokentype(t_token_type type, t_list **current)
+bool	is_tokentype(t_token_type type, t_list **current, char **buf_ptr)
 {
+	if (*current == NULL)
+		return (false);
 	if (((t_tok *)(*current)->content)->type == type)
 	{
+		if (buf_ptr != NULL)
+			*buf_ptr = ft_strdup(((t_tok *)(*current)->content)->data);
 		*current = (*current)->next;
 		return (true);
 	}

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -1,8 +1,8 @@
 #include "shell.h"
 #include "parse.h"
-#include "logging.h"
 
-bool	is_tokentype(t_token_type type, t_list **current, char **buf_ptr)
+bool	is_tokentype_and_store_data(
+			t_token_type type, t_list **current, char **buf_ptr)
 {
 	if (*current == NULL)
 		return (false);

--- a/srcs/parse/redirection.c
+++ b/srcs/parse/redirection.c
@@ -35,7 +35,7 @@ t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
 	t_astree	*tokenlist_node;
 	char		*filename;
 
-	if (!is_tokentype(t, toks))
+	if (!move_if_is_tokentype(t, toks))
 		return (NULL);
 	if (!allocate_data_if_is_token(toks, &filename))
 		return (NULL);

--- a/srcs/parse/redirection.c
+++ b/srcs/parse/redirection.c
@@ -35,9 +35,9 @@ t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
 	t_astree	*tokenlist_node;
 	char		*filename;
 
-	if (!is_tokentype(t, toks, NULL))
+	if (!is_tokentype_and_store_data(t, toks, NULL))
 		return (NULL);
-	if (!is_tokentype(TOKEN, toks, &filename))
+	if (!is_tokentype_and_store_data(TOKEN, toks, &filename))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(n | NODE_DATA, filename, NULL, tokenlist_node));

--- a/srcs/parse/redirection.c
+++ b/srcs/parse/redirection.c
@@ -1,0 +1,44 @@
+#include "parse.h"
+
+t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n);
+
+/**
+<redirection>		::= '<' <filename> <token list>
+					  | '>' <filename> <token list>
+					  | '<<' <filename> <token list>
+					  | '>>' <filename> <token list>
+// <token list> will be added after the arg of the previous <simple command>.
+*/
+t_astree	*redirection(t_list **toks)
+{
+	t_list		*save;
+	t_astree	*result;
+
+	save = *toks;
+	result = redirection1(toks, CHAR_LESSER, NODE_REDIRECT_IN);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = redirection1(toks, CHAR_GREATER, NODE_REDIRECT_OUT);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	result = redirection1(toks, CHAR_LESSER2, NODE_REDIRECT_IN2);
+	if (result != NULL)
+		return (result);
+	*toks = save;
+	return (redirection1(toks, CHAR_GREATER2, NODE_REDIRECT_OUT2));
+}
+
+t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
+{
+	t_astree	*tokenlist_node;
+	char		*filename;
+
+	if (!is_tokentype(t, toks, NULL))
+		return (NULL);
+	if (!is_tokentype(TOKEN, toks, &filename))
+		return (NULL);
+	tokenlist_node = tokenlist(toks);
+	return (astree_create_node(n | NODE_DATA, filename, NULL, tokenlist_node));
+}

--- a/srcs/parse/redirection.c
+++ b/srcs/parse/redirection.c
@@ -35,9 +35,9 @@ t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
 	t_astree	*tokenlist_node;
 	char		*filename;
 
-	if (!is_tokentype_and_store_data(t, toks, NULL))
+	if (!is_tokentype(t, toks))
 		return (NULL);
-	if (!is_tokentype_and_store_data(TOKEN, toks, &filename))
+	if (!allocate_data_if_is_token(toks, &filename))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(n | NODE_DATA, filename, NULL, tokenlist_node));

--- a/srcs/parse/redirection_list.c
+++ b/srcs/parse/redirection_list.c
@@ -1,0 +1,27 @@
+#include "parse.h"
+
+t_astree	*redirlist1(t_list **toks);
+
+/**
+ * <redirection list> ::= <redirection> <redirection list>
+ */
+t_astree	*redirlist(t_list **toks)
+{
+	return (redirlist1(toks));
+}
+
+/**
+ * <redirection list> ::= <redirection> <redirection list>
+ */
+t_astree	*redirlist1(t_list **toks)
+{
+	t_astree	*redirection_node;
+	t_astree	*redirlist_node;
+
+	redirection_node = redirection(toks);
+	if (redirection_node == NULL)
+		return (NULL);
+	redirlist_node = redirlist(toks);
+	return (astree_create_node(NODE_REDIRECT_LIST, NULL,
+			redirection_node, redirlist_node));
+}

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -18,7 +18,7 @@ t_astree	*simplecmd1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*pathname;
 
-	if (!is_tokentype(TOKEN, toks, &pathname))
+	if (!is_tokentype_and_store_data(TOKEN, toks, &pathname))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_CMDPATH | NODE_DATA, pathname,

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -1,0 +1,30 @@
+#include "parse.h"
+
+t_astree	*simplecmd1(t_list **toks); // <pathname> <token list>
+
+/**
+ * @brief <simple command>::= <pathname> <token list>
+ */
+t_astree	*simplecmd(t_list **toks)
+{
+	return (simplecmd1(toks));
+}
+
+/**
+ * @brief <simple command>::= <pathname> <token list>
+ */
+t_astree	*simplecmd1(t_list **toks)
+{
+	t_astree	*tokenlist_node;
+	char		*pathname;
+
+	pathname = ft_strdup(((t_tok *)(*toks)->content)->data);
+	if (!is_tokentype(TOKEN, toks))
+	{
+		free(pathname);
+		return (NULL);
+	}
+	tokenlist_node = tokenlist(toks);
+	return (astree_create_node(NODE_CMDPATH | NODE_DATA, pathname,
+			NULL, tokenlist_node));
+}

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -18,7 +18,7 @@ t_astree	*simplecmd1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*pathname;
 
-	if (!is_tokentype_and_store_data(TOKEN, toks, &pathname))
+	if (!allocate_data_if_is_token(toks, &pathname))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_CMDPATH | NODE_DATA, pathname,

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -18,10 +18,8 @@ t_astree	*simplecmd1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*pathname;
 
-	pathname = ft_strdup(((t_tok *)(*toks)->content)->data);
-	if (!is_tokentype(TOKEN, toks))
+	if (!is_tokentype(TOKEN, toks, &pathname))
 	{
-		free(pathname);
 		return (NULL);
 	}
 	tokenlist_node = tokenlist(toks);

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -19,9 +19,7 @@ t_astree	*simplecmd1(t_list **toks)
 	char		*pathname;
 
 	if (!is_tokentype(TOKEN, toks, &pathname))
-	{
 		return (NULL);
-	}
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_CMDPATH | NODE_DATA, pathname,
 			NULL, tokenlist_node));

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -16,10 +16,7 @@ t_astree	*tokenlist(t_list **toks)
 	node = tokenlist1(toks);
 	if (node != NULL)
 		return (node);
-	node = tokenlist2(toks);
-	if (node != NULL)
-		return (node);
-	return (NULL);
+	return (tokenlist2(toks));
 }
 
 t_astree	*tokenlist1(t_list **toks)
@@ -27,7 +24,7 @@ t_astree	*tokenlist1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*arg;
 
-	if (!is_tokentype(TOKEN, toks, &arg))
+	if (!is_tokentype_and_store_data(TOKEN, toks, &arg))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_ARGUMENT | NODE_DATA, arg,

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -24,7 +24,7 @@ t_astree	*tokenlist1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*arg;
 
-	if (!is_tokentype_and_store_data(TOKEN, toks, &arg))
+	if (!allocate_data_if_is_token(toks, &arg))
 		return (NULL);
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_ARGUMENT | NODE_DATA, arg,

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -1,0 +1,44 @@
+#include "parse.h"
+
+t_astree	*tokenlist1(t_list **toks); // <token> <token list>
+t_astree	*tokenlist2(t_list **toks); // (EMPTY)
+
+/**
+ * <token list>	::= <token> <token list>
+ *				  | (EMPTY)
+ */
+t_astree	*tokenlist(t_list **toks)
+{
+	t_list		*save;
+	t_astree	*node;
+
+	save = *toks;
+	node = tokenlist1(toks);
+	if (node != NULL)
+		return (node);
+	node = tokenlist2(toks);
+	if (node != NULL)
+		return (node);
+	return (NULL);
+}
+
+t_astree	*tokenlist1(t_list **toks)
+{
+	t_astree	*tokenlist_node;
+	char		*arg;
+
+	arg = ft_strdup(((t_tok *)(*toks)->content)->data);
+	if (!is_tokentype(TOKEN, toks))
+	{
+		free(arg);
+		return (NULL);
+	}
+	tokenlist_node = tokenlist(toks);
+	return (astree_create_node(NODE_ARGUMENT | NODE_DATA, arg,
+			NULL, tokenlist_node));
+}
+
+t_astree	*tokenlist2(t_list **toks)
+{
+	return (NULL);
+}

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -27,12 +27,8 @@ t_astree	*tokenlist1(t_list **toks)
 	t_astree	*tokenlist_node;
 	char		*arg;
 
-	arg = ft_strdup(((t_tok *)(*toks)->content)->data);
-	if (!is_tokentype(TOKEN, toks))
-	{
-		free(arg);
+	if (!is_tokentype(TOKEN, toks, &arg))
 		return (NULL);
-	}
 	tokenlist_node = tokenlist(toks);
 	return (astree_create_node(NODE_ARGUMENT | NODE_DATA, arg,
 			NULL, tokenlist_node));

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -9,10 +9,8 @@ t_astree	*tokenlist2(t_list **toks); // (EMPTY)
  */
 t_astree	*tokenlist(t_list **toks)
 {
-	t_list		*save;
 	t_astree	*node;
 
-	save = *toks;
 	node = tokenlist1(toks);
 	if (node != NULL)
 		return (node);


### PR DESCRIPTION
## 概要

* パーサーの実装とテスト
* #61
* 実装の参考[mysh](https://github.com/Swoorup/mysh)

### 前回のレビューからの変更点
* `is_tokentype_and_store_data()`を `is_tokentype()` と `allocate_data_if_is_token()`に分割
* テストを追加

## やったこと
### BNF
https://github.com/kohkubo/minishell/blob/fa2200856c8bbc2c5e7602b202179862f775d4a6/srcs/parse/parse-v2.c#L20-L43

### パース処理の全体的な説明
* パーサーはlexerが作ったトークンのリストを先頭から一つずつズラしながら、トークンの並びがBNFで定義される構文に合致しているかをBNFの上から順番に確認していきます。
* BNFを最後まで確認し終えた時、トークンのリストが最後(NULL)に到達していない時は構文エラーのメッセージを出力します。

### BNFを確認する流れ
`<command line> ::= <job> ';' <command line> `を例にします
* まず`<job>`が合致しているかどうかを確かめるために`job()`を実行します。
  * 合致していたらASTが帰り、していなかったらNULLが帰ります。
    * NULLが帰ってきたらこのBNFには合致しないので次のBNFを確認する処理に進みます。
  * `job()`内でトークンのリスト`toks`の指し示す先が一つずつズレていきます
* ASTが帰ってきたら、';'かどうかを`is_tokentype()`で確認し
* `;`の後ろが`<command line>`かどうかを再帰で確認します。
* 最後にASTを作り、左右の枝に`job()`や`command line()`から帰ってきたASTを配置してリターンします。

## やらないこと（あれば）

以下はこのプルリクの後、testsをsubtree化してからやります。
* #101 
  * ただし、lexer段階で`;`が普通の文字扱いになっているので現段階でも正しく動きます。
* #120 
* `< infile cat`のようなリダイレクト

## 動作確認・テスト

```
make test_unit TARGET="function-parse"
```

## その他
