### PR TITLE
Feature libft dependence

### DIFF
--- a/includes/lex.h
+++ b/includes/lex.h
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:06:12 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/19 17:38:48 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/25 11:52:25 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define LEX_H
 
 # include "libft.h"
+# include "libex.h"
 # define PAD 256
 
 typedef enum e_token_type

--- a/libft/libft/ft_atoi.c
+++ b/libft/libft/ft_atoi.c
@@ -6,11 +6,17 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:02:27 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/09 16:02:27 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/25 11:30:39 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
+
+/* \t \n \v \f \r ' ' */
+static int	ft_isspace(int c)
+{
+	return (('\t' <= c && c <= '\r') || c == ' ');
+}
 
 int	ft_atoi(const char *s)
 {

--- a/libft/libft/ft_split.c
+++ b/libft/libft/ft_split.c
@@ -12,6 +12,21 @@
 
 #include "libft.h"
 
+static char	**free_string_array(char **buf)
+{
+	size_t	i;
+
+	i = 0;
+	while (buf[i])
+	{
+		free(buf[i]);
+		buf[i] = NULL;
+		i++;
+	}
+	free(buf);
+	return (NULL);
+}
+
 static char	**cut_word(char const *s, char c, char **buf)
 {
 	const char	*ptr;

--- a/libft/libft/libft.h
+++ b/libft/libft/libft.h
@@ -6,25 +6,21 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:05:49 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/09 16:05:50 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/25 11:42:33 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef LIBFT_H
 # define LIBFT_H
-# include "../libex/libex.h"
 # include <unistd.h>
 # include <stdlib.h>
 # include <limits.h>
 # include <errno.h>
-# ifndef T_LIST
-#  define T_LIST
 typedef struct s_list
 {
 	void			*content;
 	struct s_list	*next;
 }	t_list;
-# endif
 
 char	*ft_strnstr(const char *haystack, const char *needle, size_t len);
 int		ft_isdigit(int c);

--- a/libft/libhash/libhash.h
+++ b/libft/libhash/libhash.h
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:08:13 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/19 14:15:07 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/25 11:41:12 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,14 +17,7 @@
 # include <stdlib.h>
 # include <stdio.h>
 # include <stdbool.h>
-# ifndef T_LIST
-#  define T_LIST
-typedef struct s_list
-{
-	void			*content;
-	struct s_list	*next;
-}	t_list;
-# endif
+
 typedef struct s_dict_item {
 	int		hash_key;
 	char	*key;


### PR DESCRIPTION
## 変更の概要

* 変更の概要

libftがlibexをincludeしていて、お互いにincludeしていたため、libexがlibftに依存するように変更

* 関連するIssueやプルリクエスト

 #156

## なぜこの変更をするのか

正しい依存関係

## やったこと

依存関係の解消、依存関係に基づいたincludeの変更

## 変更内容

libftの中で使用しているlibexの関数を、使用場所で定義するように変更

## 影響範囲

minishell全体

## 動作確認

```
make test
```

## 課題

なし

## 備考

最後にマージしないとコンフリクトを起こしそうです。