### PR TITLE
Feature ft env2  delete extern  export  unset  pwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ src =\
 	./built-in/ft_env.c \
 	./built-in/ft_export.c \
 	./built-in/ft_unset.c \
+	./built-in/ft_pwd.c \
 	./main.c \
 	./env/env.c \
 

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -30,5 +30,6 @@ void			store_shellenv(char **arr, t_hash_table *table);
 int				ft_env(char **args);
 int				ft_export(char **args);
 int				ft_unset(char **args);
+int				ft_pwd(char **args);
 
 #endif

--- a/includes/shell.h
+++ b/includes/shell.h
@@ -16,6 +16,7 @@
 typedef struct s_shell
 {
 	t_hash_table	*env;
+	char			*pwd;
 }	t_shell;
 
 extern t_shell	g_shell;

--- a/srcs/built-in/ft_pwd.c
+++ b/srcs/built-in/ft_pwd.c
@@ -1,0 +1,8 @@
+#include "shell.h"
+
+int	ft_pwd(char **args)
+{
+	(void)args;
+	printf("%s\n", g_shell.pwd);
+	return (0);
+}

--- a/srcs/env/env.c
+++ b/srcs/env/env.c
@@ -30,6 +30,7 @@ static void	env_init(void)
 	store_shellenv(environ, g_shell.env);
 	hash_remove(g_shell.env, "OLDPWD");
 	hash_setstr(g_shell.env, "OLDPWD", NULL);
+	g_shell.pwd = getcwd(NULL, 0);
 }
 
 void	minishell_init(void)

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -5,7 +5,7 @@ char				*g_reserved_words[] = {
 	"echo", "cd", "pwd", "export", "unset", "env", "exit", NULL
 };
 t_reserved_func		g_reserved_funcs[] = {
-	ft_echo, NULL, NULL, ft_export, ft_unset, ft_env, ft_exit, NULL
+	ft_echo, NULL, ft_pwd, ft_export, ft_unset, ft_env, ft_exit, NULL
 };
 
 static void	not_implemented(char *word)


### PR DESCRIPTION
## 変更の概要

* 変更の概要

pwdコマンドの追加
- pwd ユーティリティは、現在のワーキングディレクトリを絶対パスで標準出力に 出力します。
- オプションなし
- 与えられた引数はすべて無視します。

本家のpwdの違い
- 引数に取るハイフンを特殊文字ではなく、ただの文字として扱います。

* 関連するIssueやプルリクエスト

 #158

## なぜこの変更をするのか

課題PDF

## やったこと

pwd関数の実装
parse.cで呼び出しするように変更

## 変更内容

なし

## 影響範囲

parse.c

## 動作確認

```
make test_issue TARGET=pwd
```

## 課題

なし

## 備考

なし