### PR TITLE
Add: Specify the version of norme as 3.3.2

### DIFF
--- a/.github/workflows/norm.yml
+++ b/.github/workflows/norm.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Norminette.
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install norminette
+          python3 -m pip install norminette==3.3.2
 
       # Runs a single command using the runners shell
       # アクションの終了コードの設定 - GitHub Docs => 終了ステータス0以外ならfailureが出ます。


### PR DESCRIPTION
## 概要

* ノームのバージョンを3.3.2で実行するようにした

## やったこと詳細

* norminetteの最新バージョンを利用するCIだったが、3.3.3になって新たなエラーが出たので9/6以降の指定バージョンである3.3.2へ固定した。
* https://discord.com/channels/691903146909237289/691903147689508866/871678140836110366

## やらないこと（あれば）


## 動作確認・テスト

* このプルリクのactionsを参照

## その他

