### PR TITLE
Exit

### DIFF
--- a/libft/libex/Makefile
+++ b/libft/libex/Makefile
@@ -31,6 +31,8 @@ src =\
 	./random_string.c \
 	./str_arraydup.c \
 	./debug_array.c \
+	./is_num_string.c \
+	./ft_atol.c \
 
 # ***********************************
 

--- a/libft/libex/ft_atol.c
+++ b/libft/libex/ft_atol.c
@@ -1,0 +1,33 @@
+#include "libex.h"
+
+static long	ft_atol_overflow(int neg)
+{
+	errno = EINVAL;
+	if (neg == 1)
+		return (LONG_MAX);
+	else
+		return (LONG_MIN);
+}
+
+long	ft_atol(const char *s)
+{
+	long	n;
+	int		neg;
+	long	tmp;
+
+	n = 0;
+	neg = 1;
+	while (ft_isspace(*s))
+		s++;
+	if (*s == '-' || *s == '+')
+		if (*s++ == '-')
+			neg = -1;
+	while (ft_isdigit(*s))
+	{
+		tmp = n;
+		n = n * 10 + *s++ - '0';
+		if (tmp >> 60 || n >> 63)
+			return (ft_atol_overflow(neg));
+	}
+	return ((n * neg));
+}

--- a/libft/libex/is_num_string.c
+++ b/libft/libex/is_num_string.c
@@ -1,0 +1,11 @@
+#include "libex.h"
+
+bool	is_num_string(char *s)
+{
+	if (*s == '-' || *s == '+')
+		s++;
+	while (*s)
+		if (!ft_isdigit(*s++))
+			return (false);
+	return (true);
+}

--- a/libft/libex/libex.h
+++ b/libft/libex/libex.h
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:01:50 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/19 14:06:12 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/29 13:14:59 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,5 +38,7 @@ void	print_array(char **array);
 char	*random_string(size_t size);
 char	**str_arraydup(char **array);
 int		debug_arraycmp(char **aa, char **bb);
+bool	is_num_string(char *s);
+long	ft_atol(const char *s);
 
 #endif

--- a/libft/libft/ft_atoi.c
+++ b/libft/libft/ft_atoi.c
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:02:27 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/25 11:30:39 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/08/29 13:32:00 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,11 +18,20 @@ static int	ft_isspace(int c)
 	return (('\t' <= c && c <= '\r') || c == ' ');
 }
 
+static int	ft_atoi_overflow(int neg)
+{
+	errno = EINVAL;
+	if (neg == 1)
+		return ((int)LONG_MAX);
+	else
+		return ((int)LONG_MIN);
+}
+
 int	ft_atoi(const char *s)
 {
-	uint64_t	n;
-	int			neg;
-	uint64_t	tmp;
+	unsigned long	n;
+	int				neg;
+	unsigned long	tmp;
 
 	n = 0;
 	neg = 1;
@@ -36,13 +45,9 @@ int	ft_atoi(const char *s)
 		tmp = n;
 		n = n * 10 + *s++ - '0';
 		if (tmp >> 60 || n >> 63)
-		{
-			errno = EINVAL;
-			if (neg == 1)
-				return ((int)LONG_MAX);
-			else
-				return ((int)LONG_MIN);
-		}
+			return (ft_atoi_overflow(neg));
 	}
+	if (n > INT_MAX || (n == (unsigned long)INT_MAX + 1 && neg == -1))
+		errno = EINVAL;
 	return ((int)(n * neg));
 }

--- a/srcs/built-in/ft_exit.c
+++ b/srcs/built-in/ft_exit.c
@@ -1,8 +1,16 @@
 #include "shell.h"
 
-int	ft_exit(char **arg)
+int	ft_exit(char **args)
 {
-	(void)arg;
-	ft_putendl_fd("exit is not implemented yet", 1);
+	if (args[0] == NULL)
+		exit(0);
+	if (arraylen(args) != 1)
+	{
+		ft_putstr_fd("exit: too many arguments\n", 2);
+		return (1);
+	}
+	if (!is_num_string(args[0]))
+		exit(0);
+	exit((int)ft_atol(args[0]));
 	return (0);
 }


### PR DESCRIPTION
## 概要

* このプルリクの概要
exitの実装

* 関連するIssueやプルリクエスト

close #14 

## やったこと詳細

* 各関数の実装内容

ft_exitの実装。ft_exitで使用する関数をライブラリに追加

* 実装・変更の意図など

bashの終了ステータスの実装はmanに沿っていないケースがありました。



```
## おかしいケース

bash-3.2$ >>>
bash: syntax error near unexpected token `>'
bash-3.2$ echo $?
258
```

```
## man bash

EXIT STATUS
       For the shell's purposes, a command which exits with a zero exit status has succeeded.  An exit status  of  zero  indi-
       cates success.  A non-zero exit status indicates failure.  When a command terminates on a fatal signal N, bash uses the
       value of 128+N as the exit status.

       If a command is not found, the child process created to execute it returns a status of 127.  If a command is found  but
       is not executable, the return status is 126.

       If a command fails because of an error during expansion or redirection, the exit status is greater than zero.

       Shell  builtin  commands  return a status of 0 (true) if successful, and non-zero (false) if an error occurs while they
       execute.  All builtins return an exit status of 2 to indicate incorrect usage.

       Bash itself returns the exit status of the last command executed, unless a syntax error occurs, in which case it  exits
       with a non-zero value.  See also the exit builtin command below.
```

zshではそこらへんが改善されているので、exitコマンドに引数を渡した場合の挙動についてはzshに合わせています。

manには記載がありませんが、以下を渡したときの挙動もzshに合わせています。

- longの範囲外 (文言は非対応)
- 数字以外

## やらないこと（あれば）

* このプルリクでやらないことは何か？いつやるのか。

exitが複数の引数を持つケースの実装は行っておりますが、$？の実装を行っていないため、テストケースには追加しませんでした。
$?の実装が終わったらテストケースを追加するか、一気通貫のテストで行います。

## 動作確認・テスト

```
make test_issue TARGET="exit"
```

## その他

libft/ft_atoi.cで対応できるかと思っていましたが、ft_atolが必要になったので、実装しました。

その過程でft_atoiのオーバーフローについてエラーナンバーを設定するようにしたので、その変更も合わせてpushします。