### PR TITLE
fix(libhash): hash_getstr()の返り値をchar *からconst char *に変更

### DIFF
--- a/libft/libhash/hash_getstr.c
+++ b/libft/libhash/hash_getstr.c
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:07:59 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/09 16:07:59 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/09/07 17:03:16 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 ** @brief Returns the string value stored in [key].
 ** @return Returns string if successful, NULL otherwise.
 */
-char	*hash_getstr(t_hash_table *h, char *key)
+const char	*hash_getstr(t_hash_table *h, char *key)
 {
 	t_dict_item	*item;
 

--- a/libft/libhash/libhash.h
+++ b/libft/libhash/libhash.h
@@ -6,7 +6,7 @@
 /*   By: kohkubo <kohkubo@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/08/09 16:08:13 by kohkubo           #+#    #+#             */
-/*   Updated: 2021/08/30 17:38:05 by kohkubo          ###   ########.fr       */
+/*   Updated: 2021/09/07 17:09:17 by kohkubo          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ unsigned int	hasher(const char *str, int capacity);
 bool			hash_remove(t_hash_table *h, char *key);
 char			**hash_getkeys(t_hash_table *h);
 bool			hash_setstr(t_hash_table *h, char *key, char *value);
-char			*hash_getstr(t_hash_table *h, char *key);
+const char		*hash_getstr(t_hash_table *h, char *key);
 t_dict_item		*hash_search(t_hash_table *h, char *key);
 void			hash_clear_dict_item(void *item);
 char			**hash_getall(t_hash_table *h, char *(*fmt)(char *k, char *v));

--- a/tests/unit-test/function-hash/test_hash_null_set.c
+++ b/tests/unit-test/function-hash/test_hash_null_set.c
@@ -37,7 +37,7 @@ int	main()
 	hash_setstr(t, "VAL6", NULL);
 
 	// getstrできるか
-	char *val0 = hash_getstr(t, "VAL7");
+	const char *val0 = hash_getstr(t, "VAL7");
 	if (val0 != NULL)
 		exit(1);
 	// NULLが格納されているかのチェック
@@ -68,7 +68,7 @@ int	main()
 	//もともとNULLのときに上書きできるかチェック
 	test_res_null(t, "VAL5");
 	hash_setstr(t, "VAL5", "aiueo");
-	char *val5 = hash_getstr(t, "VAL5");
+	const char *val5 = hash_getstr(t, "VAL5");
 	if (strcmp(val5, "aiueo"))
 		exit(1);
 


### PR DESCRIPTION
## 概要

* このプルリクの概要
* 
hash_getstr()の返り値をchar *からconst char *に変更

* 関連するIssueやプルリクエスト

close #181

## やったこと詳細

* 実装・変更の意図など

```c
void foo( char const* s ) { // const char* s も同じ意味
   *s = 'A' ; // NG ポインタの先を書き換えできない
   s++ ;      // OK ポインタを動かすことはできる
}
void foo( char *const s ) {
   *s = 'A' ; // OK ポインタの先は書き込める
   s++ ;      // NG ポインタは動かせない
}
void foo( char const*const s ) {
   *s = 'A' ; // NG ポインタの先を書き換えできない
   s++ ;      // NG ポインタは動かせない
}
```

## やらないこと（あれば）

なし

## 動作確認・テスト

```
make test
```

## その他

なし