### PR TITLE
[Parser] Errorテストの追加

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -6,12 +6,12 @@
 
 bool		move_if_is_tokentype(t_token_type type, t_list **current);
 bool		allocate_data_if_is_token(t_list **current, char **buf_ptr);
-t_astree	*cmdline(t_list **toks);
-t_astree	*job(t_list **toks);
-t_astree	*cmd(t_list **toks);
-t_astree	*redirlist(t_list **toks);
-t_astree	*redirection(t_list **toks);
-t_astree	*simplecmd(t_list **toks);
-t_astree	*tokenlist(t_list **toks);
+t_astree	*cmdline(t_list **toks, bool *has_error);
+t_astree	*job(t_list **toks, bool *has_error);
+t_astree	*cmd(t_list **toks, bool *has_error);
+t_astree	*redirlist(t_list **toks, bool *has_error);
+t_astree	*redirection(t_list **toks, bool *has_error);
+t_astree	*simplecmd(t_list **toks, bool *has_error);
+t_astree	*tokenlist(t_list **toks, bool *has_error);
 
 #endif

--- a/srcs/parse/command.c
+++ b/srcs/parse/command.c
@@ -1,38 +1,39 @@
 #include "parse.h"
 
-t_astree	*cmd1(t_list **toks); // <simple command> <redirection list>
-t_astree	*cmd2(t_list **toks); // <simple command>
+// <simple command> <redirection list>
+t_astree	*cmd1(t_list **toks, bool *has_error);
+t_astree	*cmd2(t_list **toks, bool *has_error); // <simple command>
 void		collect_args(t_astree *simplecmd_node, t_astree *redirlist_node);
 
 /**
  * @brief <command>	::= <simple command> <redirection list>
  *					  | <simple command>
  */
-t_astree	*cmd(t_list **toks)
+t_astree	*cmd(t_list **toks, bool *has_error)
 {
 	t_list		*save;
 	t_astree	*result;
 
 	save = *toks;
-	result = cmd1(toks);
-	if (result != NULL)
+	result = cmd1(toks, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	return (cmd2(toks));
+	return (cmd2(toks, has_error));
 }
 
 /**
  * <command> ::= <simple command> <redirection list>
  */
-t_astree	*cmd1(t_list **toks)
+t_astree	*cmd1(t_list **toks, bool *has_error)
 {
 	t_astree	*simplecmd_node;
 	t_astree	*redirlist_node;
 
-	simplecmd_node = simplecmd(toks);
+	simplecmd_node = simplecmd(toks, has_error);
 	if (simplecmd_node == NULL)
 		return (NULL);
-	redirlist_node = redirlist(toks);
+	redirlist_node = redirlist(toks, has_error);
 	if (redirlist_node == NULL)
 		return (astree_delete_node(simplecmd_node));
 	collect_args(simplecmd_node, redirlist_node);
@@ -43,9 +44,9 @@ t_astree	*cmd1(t_list **toks)
 /**
  * <command> ::= <simple command>
  */
-t_astree	*cmd2(t_list **toks)
+t_astree	*cmd2(t_list **toks, bool *has_error)
 {
-	return (simplecmd(toks));
+	return (simplecmd(toks, has_error));
 }
 
 void	collect_args(t_astree *simplecmd_node, t_astree *redirlist_node)

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -1,7 +1,7 @@
 #include "parse.h"
-t_astree	*cmdline1(t_list **toks); // <job> ';' <command line>
-t_astree	*cmdline2(t_list **toks); // <job> ';'
-t_astree	*cmdline3(t_list **toks); // <job>
+t_astree	*cmdline1(t_list **toks, bool *has_error); // <job>';'<command line>
+t_astree	*cmdline2(t_list **toks, bool *has_error); // <job> ';'
+t_astree	*cmdline3(t_list **toks, bool *has_error); // <job>
 
 /*
 ** <command line>	::= <job> ';' <command line>
@@ -10,50 +10,53 @@ t_astree	*cmdline3(t_list **toks); // <job>
 **					  | <job> '&'					// not make
 **					  | <job>
 */
-t_astree	*cmdline(t_list **toks)
+t_astree	*cmdline(t_list **toks, bool *has_error)
 {
 	t_list		*save;
 	t_astree	*result;
 
 	save = *toks;
-	result = cmdline1(toks);
-	if (result != NULL)
+	result = cmdline1(toks, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	result = cmdline2(toks);
-	if (result != NULL)
+	result = cmdline2(toks, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	return (cmdline3(toks));
+	return (cmdline3(toks, has_error));
 }
 
 /*
 ** @brief <command line> ::= <job> ';' <command line>
 */
-t_astree	*cmdline1(t_list **toks)
+t_astree	*cmdline1(t_list **toks, bool *has_error)
 {
 	t_astree	*job_node;
 	t_astree	*cmdline_node;
 
-	job_node = job(toks);
+	job_node = job(toks, has_error);
 	if (job_node == NULL)
 		return (NULL);
 	if (!move_if_is_tokentype(CHAR_SEMICOLON, toks))
 		return (astree_delete_node(job_node));
-	cmdline_node = cmdline(toks);
+	cmdline_node = cmdline(toks, has_error);
 	if (cmdline_node == NULL)
+	{
+		*has_error = true;
 		return (astree_delete_node(job_node));
+	}
 	return (astree_create_node(NODE_SEQ, NULL, job_node, cmdline_node));
 }
 
 /*
 ** @brief <command line> ::= <job> ';'
 */
-t_astree	*cmdline2(t_list **toks)
+t_astree	*cmdline2(t_list **toks, bool *has_error)
 {
 	t_astree	*job_node;
 
-	job_node = job(toks);
+	job_node = job(toks, has_error);
 	if (job_node == NULL)
 		return (NULL);
 	if (!move_if_is_tokentype(CHAR_SEMICOLON, toks))
@@ -64,7 +67,7 @@ t_astree	*cmdline2(t_list **toks)
 /*
 ** @brief <command line> ::= <job>
 */
-t_astree	*cmdline3(t_list **toks)
+t_astree	*cmdline3(t_list **toks, bool *has_error)
 {
-	return (job(toks));
+	return (job(toks, has_error));
 }

--- a/srcs/parse/command_line.c
+++ b/srcs/parse/command_line.c
@@ -42,10 +42,7 @@ t_astree	*cmdline1(t_list **toks, bool *has_error)
 		return (astree_delete_node(job_node));
 	cmdline_node = cmdline(toks, has_error);
 	if (cmdline_node == NULL)
-	{
-		*has_error = true;
 		return (astree_delete_node(job_node));
-	}
 	return (astree_create_node(NODE_SEQ, NULL, job_node, cmdline_node));
 }
 

--- a/srcs/parse/job.c
+++ b/srcs/parse/job.c
@@ -1,48 +1,51 @@
 #include "parse.h"
 
-t_astree	*job1(t_list **toks); // <command> '|' <job>
-t_astree	*job2(t_list **toks); // <command>
+t_astree	*job1(t_list **toks, bool *has_error); // <command> '|' <job>
+t_astree	*job2(t_list **toks, bool *has_error); // <command>
 
 /*
 ** <job>			::= <command> '|' <job>
 **					  | <command>
 */
-t_astree	*job(t_list **toks)
+t_astree	*job(t_list **toks, bool *has_error)
 {
 	t_list		*save;
 	t_astree	*result;
 
 	save = *toks;
-	result = job1(toks);
-	if (result != NULL)
+	result = job1(toks, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	return (job2(toks));
+	return (job2(toks, has_error));
 }
 
 /*
 ** @brief <job> ::= <command> '|' <job>
 */
-t_astree	*job1(t_list **toks)
+t_astree	*job1(t_list **toks, bool *has_error)
 {
 	t_astree	*cmd_node;
 	t_astree	*job_node;
 
-	cmd_node = cmd(toks);
+	cmd_node = cmd(toks, has_error);
 	if (cmd_node == NULL)
 		return (NULL);
 	if (!move_if_is_tokentype(CHAR_PIPE, toks))
 		return (astree_delete_node(cmd_node));
-	job_node = job(toks);
+	job_node = job(toks, has_error);
 	if (job_node == NULL)
+	{
+		*has_error = true;
 		return (astree_delete_node(cmd_node));
+	}
 	return (astree_create_node(NODE_PIPE, NULL, cmd_node, job_node));
 }
 
 /*
 ** @brief <job> ::= <command>
 */
-t_astree	*job2(t_list **toks)
+t_astree	*job2(t_list **toks, bool *has_error)
 {
-	return (cmd(toks));
+	return (cmd(toks, has_error));
 }

--- a/srcs/parse/parse-v2.c
+++ b/srcs/parse/parse-v2.c
@@ -55,15 +55,20 @@ bool	allocate_data_if_is_token(t_list **current, char **buf_ptr)
 bool	parse_v2(t_lexer *lex, t_astree **res_buf)
 {
 	t_list	*tokens;
+	bool	has_error;
 
 	if (res_buf == NULL)
 		return (false);
+	has_error = false;
 	tokens = lex->listtok;
-	*res_buf = cmdline(&tokens);
-	if (tokens != NULL && ((t_tok *)tokens->content)->type != CHAR_NULL)
+	*res_buf = cmdline(&tokens, &has_error);
+	if (tokens != NULL || has_error)
 	{
 		ft_putstr_fd("syntax error near unexpected token `", 2);
-		ft_putstr_fd(((t_tok *)tokens->content)->data, 2);
+		if (tokens == NULL)
+			ft_putstr_fd("newline", 2);
+		else
+			ft_putstr_fd(((t_tok *)tokens->content)->data, 2);
 		ft_putendl_fd("'", 2);
 		return (false);
 	}

--- a/srcs/parse/redirection.c
+++ b/srcs/parse/redirection.c
@@ -1,6 +1,7 @@
 #include "parse.h"
 
-t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n);
+t_astree	*redirection1(
+				t_list **toks, t_token_type t, t_node_type n, bool *has_error);
 
 /**
 <redirection>		::= '<' <filename> <token list>
@@ -9,28 +10,29 @@ t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n);
 					  | '>>' <filename> <token list>
 // <token list> will be added after the arg of the previous <simple command>.
 */
-t_astree	*redirection(t_list **toks)
+t_astree	*redirection(t_list **toks, bool *has_error)
 {
 	t_list		*save;
 	t_astree	*result;
 
 	save = *toks;
-	result = redirection1(toks, CHAR_LESSER, NODE_REDIRECT_IN);
-	if (result != NULL)
+	result = redirection1(toks, CHAR_LESSER, NODE_REDIRECT_IN, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	result = redirection1(toks, CHAR_GREATER, NODE_REDIRECT_OUT);
-	if (result != NULL)
+	result = redirection1(toks, CHAR_GREATER, NODE_REDIRECT_OUT, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	result = redirection1(toks, CHAR_LESSER2, NODE_REDIRECT_IN2);
-	if (result != NULL)
+	result = redirection1(toks, CHAR_LESSER2, NODE_REDIRECT_IN2, has_error);
+	if (result != NULL || *has_error)
 		return (result);
 	*toks = save;
-	return (redirection1(toks, CHAR_GREATER2, NODE_REDIRECT_OUT2));
+	return (redirection1(toks, CHAR_GREATER2, NODE_REDIRECT_OUT2, has_error));
 }
 
-t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
+t_astree	*redirection1(
+				t_list **toks, t_token_type t, t_node_type n, bool *has_error)
 {
 	t_astree	*tokenlist_node;
 	char		*filename;
@@ -38,7 +40,10 @@ t_astree	*redirection1(t_list **toks, t_token_type t, t_node_type n)
 	if (!move_if_is_tokentype(t, toks))
 		return (NULL);
 	if (!allocate_data_if_is_token(toks, &filename))
+	{
+		*has_error = true;
 		return (NULL);
-	tokenlist_node = tokenlist(toks);
+	}
+	tokenlist_node = tokenlist(toks, has_error);
 	return (astree_create_node(n | NODE_DATA, filename, NULL, tokenlist_node));
 }

--- a/srcs/parse/redirection_list.c
+++ b/srcs/parse/redirection_list.c
@@ -1,27 +1,27 @@
 #include "parse.h"
 
-t_astree	*redirlist1(t_list **toks);
+t_astree	*redirlist1(t_list **toks, bool *has_error);
 
 /**
  * <redirection list> ::= <redirection> <redirection list>
  */
-t_astree	*redirlist(t_list **toks)
+t_astree	*redirlist(t_list **toks, bool *has_error)
 {
-	return (redirlist1(toks));
+	return (redirlist1(toks, has_error));
 }
 
 /**
  * <redirection list> ::= <redirection> <redirection list>
  */
-t_astree	*redirlist1(t_list **toks)
+t_astree	*redirlist1(t_list **toks, bool *has_error)
 {
 	t_astree	*redirection_node;
 	t_astree	*redirlist_node;
 
-	redirection_node = redirection(toks);
+	redirection_node = redirection(toks, has_error);
 	if (redirection_node == NULL)
 		return (NULL);
-	redirlist_node = redirlist(toks);
+	redirlist_node = redirlist(toks, has_error);
 	return (astree_create_node(NODE_REDIRECT_LIST, NULL,
 			redirection_node, redirlist_node));
 }

--- a/srcs/parse/simple_command.c
+++ b/srcs/parse/simple_command.c
@@ -1,26 +1,27 @@
 #include "parse.h"
 
-t_astree	*simplecmd1(t_list **toks); // <pathname> <token list>
+// <pathname> <token list>
+t_astree	*simplecmd1(t_list **toks, bool *has_error);
 
 /**
  * @brief <simple command>::= <pathname> <token list>
  */
-t_astree	*simplecmd(t_list **toks)
+t_astree	*simplecmd(t_list **toks, bool *has_error)
 {
-	return (simplecmd1(toks));
+	return (simplecmd1(toks, has_error));
 }
 
 /**
  * @brief <simple command>::= <pathname> <token list>
  */
-t_astree	*simplecmd1(t_list **toks)
+t_astree	*simplecmd1(t_list **toks, bool *has_error)
 {
 	t_astree	*tokenlist_node;
 	char		*pathname;
 
 	if (!allocate_data_if_is_token(toks, &pathname))
 		return (NULL);
-	tokenlist_node = tokenlist(toks);
+	tokenlist_node = tokenlist(toks, has_error);
 	return (astree_create_node(NODE_CMDPATH | NODE_DATA, pathname,
 			NULL, tokenlist_node));
 }

--- a/srcs/parse/token_list.c
+++ b/srcs/parse/token_list.c
@@ -1,36 +1,37 @@
 #include "parse.h"
 
-t_astree	*tokenlist1(t_list **toks); // <token> <token list>
-t_astree	*tokenlist2(t_list **toks); // (EMPTY)
+t_astree	*tokenlist1(t_list **toks, bool *has_error); // <token> <token list>
+t_astree	*tokenlist2(t_list **toks, bool *has_error); // (EMPTY)
 
 /**
  * <token list>	::= <token> <token list>
  *				  | (EMPTY)
  */
-t_astree	*tokenlist(t_list **toks)
+t_astree	*tokenlist(t_list **toks, bool *has_error)
 {
 	t_astree	*node;
 
-	node = tokenlist1(toks);
-	if (node != NULL)
+	node = tokenlist1(toks, has_error);
+	if (node != NULL || *has_error)
 		return (node);
-	return (tokenlist2(toks));
+	return (tokenlist2(toks, has_error));
 }
 
-t_astree	*tokenlist1(t_list **toks)
+t_astree	*tokenlist1(t_list **toks, bool *has_error)
 {
 	t_astree	*tokenlist_node;
 	char		*arg;
 
 	if (!allocate_data_if_is_token(toks, &arg))
 		return (NULL);
-	tokenlist_node = tokenlist(toks);
+	tokenlist_node = tokenlist(toks, has_error);
 	return (astree_create_node(NODE_ARGUMENT | NODE_DATA, arg,
 			NULL, tokenlist_node));
 }
 
-t_astree	*tokenlist2(t_list **toks)
+t_astree	*tokenlist2(t_list **toks, bool *has_error)
 {
 	(void)toks;
+	(void)has_error;
 	return (NULL);
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -9,6 +9,7 @@
 !unit-test/execute/tester.py
 !unit-test/function-ft_echo_test/expect2
 !unit-test/function-lex/expect
+!unit-test/function-parse/error_case_expect
 !issue/heredoc_test/expect
 !issue/heredoc_test/*.txt
 !*case*.txt

--- a/tests/unit-test/function-parse/error_case_expect
+++ b/tests/unit-test/function-parse/error_case_expect
@@ -1,0 +1,5 @@
+syntax error near unexpected token `newline'
+syntax error near unexpected token `|''
+syntax error near unexpected token `newline'
+syntax error near unexpected token `>'
+syntax error near unexpected token `;;'

--- a/tests/unit-test/function-parse/for_error_test.c
+++ b/tests/unit-test/function-parse/for_error_test.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "shell.h"
+#include "lex.h"
+
+int main(int argc, char *argv[])
+{
+	t_lexer		*lex;
+	t_astree	*tree;
+
+	printf("%s\n", argv[1]);
+	// minishell_lexer(argv[1], &lex);
+	// parse_v2(lex, &tree);
+}

--- a/tests/unit-test/function-parse/for_error_test.c
+++ b/tests/unit-test/function-parse/for_error_test.c
@@ -1,16 +1,89 @@
 #include <stdio.h>
 #include "shell.h"
 #include "lex.h"
+#include "logging.h"
 
-int main(int argc, char *argv[])
+t_tok	*new_token(char *data, t_token_type	type)
+{
+	t_tok	*ret;
+
+	ret = malloc(sizeof(t_tok));
+	if (data)
+		ret->data = ft_strdup(data);
+	else
+		ret->data = NULL;
+	ret->type = type;
+	return (ret);
+}
+
+void	test(t_tok **toks)
 {
 	t_lexer		*lex;
 	t_astree	*tree;
 	bool		isSuccess;
+	char		*str;
 
-	minishell_lexer(argv[1], &lex);
+	lex = lexer_init();
+	str = ft_strdup("");
+	while (*toks)
+	{
+		ft_lstadd_back(&lex->listtok, ft_lstnew(new_token((*toks)->data, (*toks)->type)));
+		free_set((void **)&str, ft_strjoin(str, (*toks)->data));
+		free_set((void **)&str, ft_strjoin(str, " "));
+		toks++;
+	}
 	isSuccess = parse_v2(lex, &tree);
 	lexer_free(&lex);
 	tree = astree_delete_node(tree);
-	return (!isSuccess);
+	printf("%s%s\n", str, !isSuccess ? GREEN"✓"END : RED"×"END);
+	free(str);
+}
+
+int main(int argc, char *argv[])
+{
+	bool		success;
+
+	/**
+	 * a |
+	 */
+	test((t_tok *[]){
+		&(t_tok){.data = "a", .type = TOKEN},
+		&(t_tok){.data = "|", .type = CHAR_PIPE},
+		NULL
+	});
+	/**
+	 * a | |
+	 */
+	test((t_tok *[]){
+		&(t_tok){.data = "a", .type = TOKEN},
+		&(t_tok){.data = "|", .type = CHAR_PIPE},
+		&(t_tok){.data = "|'", .type = CHAR_PIPE},
+		NULL
+	});
+	/**
+	 * a >
+	 */
+	test((t_tok *[]){
+		&(t_tok){.data = "a", .type = TOKEN},
+		&(t_tok){.data = ">", .type = CHAR_GREATER},
+		NULL
+	});
+	/**
+	 * a >> >
+	 */
+	test((t_tok *[]){
+		&(t_tok){.data = "a", .type = TOKEN},
+		&(t_tok){.data = ">>", .type = CHAR_GREATER2},
+		&(t_tok){.data = ">", .type = CHAR_GREATER},
+		NULL
+	});
+	/**
+	 * a ; ;;
+	 */
+	test((t_tok *[]){
+		&(t_tok){.data = "a", .type = TOKEN},
+		&(t_tok){.data = ";", .type = ';'},
+		&(t_tok){.data = ";;", .type = ';' + 128},
+		NULL
+	});
 }

--- a/tests/unit-test/function-parse/for_error_test.c
+++ b/tests/unit-test/function-parse/for_error_test.c
@@ -44,10 +44,11 @@ int	main(int argc, char *argv[])
 {
 	bool		result;
 
+	result = true;
 	/**
 	 * a |
 	 */
-	result |= test((t_tok *[]){
+	result &= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = "|", .type = CHAR_PIPE},
 		NULL
@@ -55,7 +56,7 @@ int	main(int argc, char *argv[])
 	/**
 	 * a | |
 	 */
-	result |= test((t_tok *[]){
+	result &= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = "|", .type = CHAR_PIPE},
 		&(t_tok){.data = "|'", .type = CHAR_PIPE},
@@ -64,7 +65,7 @@ int	main(int argc, char *argv[])
 	/**
 	 * a >
 	 */
-	result |= test((t_tok *[]){
+	result &= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ">", .type = CHAR_GREATER},
 		NULL
@@ -72,7 +73,7 @@ int	main(int argc, char *argv[])
 	/**
 	 * a >> >
 	 */
-	result |= test((t_tok *[]){
+	result &= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ">>", .type = CHAR_GREATER2},
 		&(t_tok){.data = ">", .type = CHAR_GREATER},
@@ -81,7 +82,7 @@ int	main(int argc, char *argv[])
 	/**
 	 * a ; ;;
 	 */
-	result |= test((t_tok *[]){
+	result &= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ";", .type = ';'},
 		&(t_tok){.data = ";;", .type = ';' + 128},

--- a/tests/unit-test/function-parse/for_error_test.c
+++ b/tests/unit-test/function-parse/for_error_test.c
@@ -6,8 +6,11 @@ int main(int argc, char *argv[])
 {
 	t_lexer		*lex;
 	t_astree	*tree;
+	bool		isSuccess;
 
-	printf("%s\n", argv[1]);
-	// minishell_lexer(argv[1], &lex);
-	// parse_v2(lex, &tree);
+	minishell_lexer(argv[1], &lex);
+	isSuccess = parse_v2(lex, &tree);
+	lexer_free(&lex);
+	tree = astree_delete_node(tree);
+	return (!isSuccess);
 }

--- a/tests/unit-test/function-parse/for_error_test.c
+++ b/tests/unit-test/function-parse/for_error_test.c
@@ -16,7 +16,7 @@ t_tok	*new_token(char *data, t_token_type	type)
 	return (ret);
 }
 
-void	test(t_tok **toks)
+bool	test(t_tok **toks)
 {
 	t_lexer		*lex;
 	t_astree	*tree;
@@ -37,16 +37,17 @@ void	test(t_tok **toks)
 	tree = astree_delete_node(tree);
 	printf("%s%s\n", str, !isSuccess ? GREEN"✓"END : RED"×"END);
 	free(str);
+	return (!isSuccess);
 }
 
-int main(int argc, char *argv[])
+int	main(int argc, char *argv[])
 {
-	bool		success;
+	bool		result;
 
 	/**
 	 * a |
 	 */
-	test((t_tok *[]){
+	result |= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = "|", .type = CHAR_PIPE},
 		NULL
@@ -54,7 +55,7 @@ int main(int argc, char *argv[])
 	/**
 	 * a | |
 	 */
-	test((t_tok *[]){
+	result |= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = "|", .type = CHAR_PIPE},
 		&(t_tok){.data = "|'", .type = CHAR_PIPE},
@@ -63,7 +64,7 @@ int main(int argc, char *argv[])
 	/**
 	 * a >
 	 */
-	test((t_tok *[]){
+	result |= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ">", .type = CHAR_GREATER},
 		NULL
@@ -71,7 +72,7 @@ int main(int argc, char *argv[])
 	/**
 	 * a >> >
 	 */
-	test((t_tok *[]){
+	result |= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ">>", .type = CHAR_GREATER2},
 		&(t_tok){.data = ">", .type = CHAR_GREATER},
@@ -80,10 +81,11 @@ int main(int argc, char *argv[])
 	/**
 	 * a ; ;;
 	 */
-	test((t_tok *[]){
+	result |= test((t_tok *[]){
 		&(t_tok){.data = "a", .type = TOKEN},
 		&(t_tok){.data = ";", .type = ';'},
 		&(t_tok){.data = ";;", .type = ';' + 128},
 		NULL
 	});
+	return (!result);
 }

--- a/tests/unit-test/function-parse/test.c
+++ b/tests/unit-test/function-parse/test.c
@@ -91,7 +91,7 @@ bool	compare(t_astree *ex, t_astree *ac)
 	return (compare(ex->right, ac->right));
 }
 
-void	test(bool varbose, char *input, t_astree *expect_tree)
+bool	test(bool varbose, char *input, t_astree *expect_tree)
 {
 	t_lexer		*lex;
 	t_astree	*res_tree;
@@ -119,19 +119,25 @@ void	test(bool varbose, char *input, t_astree *expect_tree)
 	res_tree = astree_delete_node(res_tree);
 	expect_tree = astree_delete_node(expect_tree);
 	if (res_flg && is_ok)
+	{
 		printf(GREEN" ✓\n"END);
+		return (true);
+	}
 	else
 	{
 		printf(RED" ×\n"END);
 		if (!res_flg)
 			fprintf(stderr, RED"return val is different.\n"END);
+		return (false);
 	}
 }
 
 int main(void) {
 	bool	varbose;
+	bool	result;
 
 	varbose = false;
+	result = false;
 	// バッファリング無効
 	setvbuf(stdout, 0, _IONBF, 0);
 	setvbuf(stderr, 0, _IONBF, 0);
@@ -139,28 +145,28 @@ int main(void) {
 	 * <token list> ::= (EMPTY)
 	 */
 	printf("(no-length string)");
-	test(varbose, "", NULL);
+	result |= test(varbose, "", NULL);
 	printf("(white space only)");
-	test(varbose, "    ", NULL);
+	result |= test(varbose, "    ", NULL);
 	/*
 	 * <token list>		::= <token> <token list>
 	 * <simple command>	::= <pathname> <token list>
 	 * <command>		::= <simple command>
 	 */
 	// <pathname> (EMPTY)
-	test(varbose, "pwd",
+	result |= test(varbose, "pwd",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("pwd"),
 			NULL, // LEFT
 			NULL)); // RIGHT
 	// <pathname> <token>
-	test(varbose, "echo a",
+	result |= test(varbose, "echo a",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("echo"),
 			NULL,
 			astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("a"),
 				NULL,
 				NULL)));
 	// <pathname> <token list>
-	test(varbose, "token1 token2 token3 token4",
+	result |= test(varbose, "token1 token2 token3 token4",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("token1"),
 			NULL,
 			astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("token2"),
@@ -177,7 +183,7 @@ int main(void) {
 	 * <redirection>		::= '<' <filename> <token list>
 	 */
 	// <simple command> <redirection>
-	test(varbose, "cat < in1",
+	result |= test(varbose, "cat < in1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA,
 				strdup("cat"),
@@ -188,7 +194,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	test(varbose, "cat > out1",
+	result |= test(varbose, "cat > out1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -198,7 +204,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	test(varbose, "cat >> out1",
+	result |= test(varbose, "cat >> out1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA,
 				strdup("cat"),
@@ -210,7 +216,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// // <simple command> <redirection list>
-	test(varbose, "cat < in1 < in2",
+	result |= test(varbose, "cat < in1 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -224,7 +230,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat > out1 > out2",
+	result |= test(varbose, "cat > out1 > out2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -238,7 +244,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat >> out1 >> out2",
+	result |= test(varbose, "cat >> out1 >> out2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -253,7 +259,7 @@ int main(void) {
 							NULL),
 						NULL))));
 	// // <simple command> <redirection> <token>
-	test(varbose, "cat < in1 arg1",
+	result |= test(varbose, "cat < in1 arg1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -265,7 +271,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	test(varbose, "cat arg1 < in1 arg2",
+	result |= test(varbose, "cat arg1 < in1 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -280,7 +286,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// <simple command> <redirection> <token list>
-	test(varbose, "cat < in1 arg1 arg2",
+	result |= test(varbose, "cat < in1 arg1 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -294,7 +300,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	test(varbose, "cat arg1 < in1 arg2 arg3",
+	result |= test(varbose, "cat arg1 < in1 arg2 arg3",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -311,7 +317,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// <simple command> <redirection list> <token>
-	test(varbose, "cat < in1 < in2 arg1",
+	result |= test(varbose, "cat < in1 < in2 arg1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -327,7 +333,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat arg1 < in1 < in2 arg2",
+	result |= test(varbose, "cat arg1 < in1 < in2 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -345,7 +351,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat < in1 arg1 < in2",
+	result |= test(varbose, "cat < in1 arg1 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -361,7 +367,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat arg1 < in1 arg2 < in2 arg3",
+	result |= test(varbose, "cat arg1 < in1 arg2 < in2 arg3",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -382,7 +388,7 @@ int main(void) {
 							NULL),
 						NULL))));
 	// <simple command> <redirection list> <token list>
-	test(varbose, "cat < in1 arg1 arg2 < in2",
+	result |= test(varbose, "cat < in1 arg1 arg2 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -400,7 +406,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat arg1 arg2 < in1 arg3 arg4 < in2 arg5 arg6",
+	result |= test(varbose, "cat arg1 arg2 < in1 arg3 arg4 < in2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -426,7 +432,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat arg1 arg2 > out1 arg3 arg4 > out2 arg5 arg6",
+	result |= test(varbose, "cat arg1 arg2 > out1 arg3 arg4 > out2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -452,7 +458,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	test(varbose, "cat arg1 arg2 >> out1 arg3 arg4 >> out2 arg5 arg6",
+	result |= test(varbose, "cat arg1 arg2 >> out1 arg3 arg4 >> out2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -496,7 +502,7 @@ int main(void) {
 	 * <job> ::= <command>
 	 * <job> ::= <command> '|' <job>
 	 */
-	test(varbose, "echo arg1 | tr a A",
+	result |= test(varbose, "echo arg1 | tr a A",
 		astree_create_node(NODE_PIPE, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("echo"),
 				NULL,
@@ -510,7 +516,7 @@ int main(void) {
 						astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("A"),
 							NULL,
 							NULL)))));
-	test(varbose, "a | b | c",
+	result |= test(varbose, "a | b | c",
 		astree_create_node(NODE_PIPE, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("a"),
 				NULL,
@@ -537,4 +543,5 @@ int main(void) {
 	//  * <command line> ::= <job> & // not make
 	//  * <command line> ::= <job> & <command line> // not make
 	//  */
+	return (!result);
 }

--- a/tests/unit-test/function-parse/test.c
+++ b/tests/unit-test/function-parse/test.c
@@ -137,7 +137,7 @@ int main(void) {
 	bool	result;
 
 	varbose = false;
-	result = false;
+	result = true;
 	// バッファリング無効
 	setvbuf(stdout, 0, _IONBF, 0);
 	setvbuf(stderr, 0, _IONBF, 0);
@@ -145,28 +145,28 @@ int main(void) {
 	 * <token list> ::= (EMPTY)
 	 */
 	printf("(no-length string)");
-	result |= test(varbose, "", NULL);
+	result &= test(varbose, "", NULL);
 	printf("(white space only)");
-	result |= test(varbose, "    ", NULL);
+	result &= test(varbose, "    ", NULL);
 	/*
 	 * <token list>		::= <token> <token list>
 	 * <simple command>	::= <pathname> <token list>
 	 * <command>		::= <simple command>
 	 */
 	// <pathname> (EMPTY)
-	result |= test(varbose, "pwd",
+	result &= test(varbose, "pwd",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("pwd"),
 			NULL, // LEFT
 			NULL)); // RIGHT
 	// <pathname> <token>
-	result |= test(varbose, "echo a",
+	result &= test(varbose, "echo a",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("echo"),
 			NULL,
 			astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("a"),
 				NULL,
 				NULL)));
 	// <pathname> <token list>
-	result |= test(varbose, "token1 token2 token3 token4",
+	result &= test(varbose, "token1 token2 token3 token4",
 		astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("token1"),
 			NULL,
 			astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("token2"),
@@ -183,7 +183,7 @@ int main(void) {
 	 * <redirection>		::= '<' <filename> <token list>
 	 */
 	// <simple command> <redirection>
-	result |= test(varbose, "cat < in1",
+	result &= test(varbose, "cat < in1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA,
 				strdup("cat"),
@@ -194,7 +194,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	result |= test(varbose, "cat > out1",
+	result &= test(varbose, "cat > out1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -204,7 +204,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	result |= test(varbose, "cat >> out1",
+	result &= test(varbose, "cat >> out1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA,
 				strdup("cat"),
@@ -216,7 +216,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// // <simple command> <redirection list>
-	result |= test(varbose, "cat < in1 < in2",
+	result &= test(varbose, "cat < in1 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -230,7 +230,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat > out1 > out2",
+	result &= test(varbose, "cat > out1 > out2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -244,7 +244,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat >> out1 >> out2",
+	result &= test(varbose, "cat >> out1 >> out2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -259,7 +259,7 @@ int main(void) {
 							NULL),
 						NULL))));
 	// // <simple command> <redirection> <token>
-	result |= test(varbose, "cat < in1 arg1",
+	result &= test(varbose, "cat < in1 arg1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -271,7 +271,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	result |= test(varbose, "cat arg1 < in1 arg2",
+	result &= test(varbose, "cat arg1 < in1 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -286,7 +286,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// <simple command> <redirection> <token list>
-	result |= test(varbose, "cat < in1 arg1 arg2",
+	result &= test(varbose, "cat < in1 arg1 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -300,7 +300,7 @@ int main(void) {
 					NULL,
 					NULL),
 				NULL)));
-	result |= test(varbose, "cat arg1 < in1 arg2 arg3",
+	result &= test(varbose, "cat arg1 < in1 arg2 arg3",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -317,7 +317,7 @@ int main(void) {
 					NULL),
 				NULL)));
 	// <simple command> <redirection list> <token>
-	result |= test(varbose, "cat < in1 < in2 arg1",
+	result &= test(varbose, "cat < in1 < in2 arg1",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -333,7 +333,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat arg1 < in1 < in2 arg2",
+	result &= test(varbose, "cat arg1 < in1 < in2 arg2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -351,7 +351,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat < in1 arg1 < in2",
+	result &= test(varbose, "cat < in1 arg1 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -367,7 +367,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat arg1 < in1 arg2 < in2 arg3",
+	result &= test(varbose, "cat arg1 < in1 arg2 < in2 arg3",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -388,7 +388,7 @@ int main(void) {
 							NULL),
 						NULL))));
 	// <simple command> <redirection list> <token list>
-	result |= test(varbose, "cat < in1 arg1 arg2 < in2",
+	result &= test(varbose, "cat < in1 arg1 arg2 < in2",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -406,7 +406,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat arg1 arg2 < in1 arg3 arg4 < in2 arg5 arg6",
+	result &= test(varbose, "cat arg1 arg2 < in1 arg3 arg4 < in2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -432,7 +432,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat arg1 arg2 > out1 arg3 arg4 > out2 arg5 arg6",
+	result &= test(varbose, "cat arg1 arg2 > out1 arg3 arg4 > out2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -458,7 +458,7 @@ int main(void) {
 							NULL,
 							NULL),
 						NULL))));
-	result |= test(varbose, "cat arg1 arg2 >> out1 arg3 arg4 >> out2 arg5 arg6",
+	result &= test(varbose, "cat arg1 arg2 >> out1 arg3 arg4 >> out2 arg5 arg6",
 		astree_create_node(NODE_REDIRECTION, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("cat"),
 				NULL,
@@ -502,7 +502,7 @@ int main(void) {
 	 * <job> ::= <command>
 	 * <job> ::= <command> '|' <job>
 	 */
-	result |= test(varbose, "echo arg1 | tr a A",
+	result &= test(varbose, "echo arg1 | tr a A",
 		astree_create_node(NODE_PIPE, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("echo"),
 				NULL,
@@ -516,7 +516,7 @@ int main(void) {
 						astree_create_node(NODE_ARGUMENT | NODE_DATA, strdup("A"),
 							NULL,
 							NULL)))));
-	result |= test(varbose, "a | b | c",
+	result &= test(varbose, "a | b | c",
 		astree_create_node(NODE_PIPE, NULL,
 			astree_create_node(NODE_CMDPATH | NODE_DATA, strdup("a"),
 				NULL,

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -10,12 +10,13 @@ DIR="$(dirname "$0")"
 
 EXIT_CODE=0
 gcc -g $INCLUDES \
+-o $DIR/a.out \
 $DIR/test.c \
 $(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
 $(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
 $SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
 
-./a.out
+$DIR/a.out
 AOUT=$?
 
 if [ $AOUT -ne 0 ]; then
@@ -25,25 +26,36 @@ else
 	printf "\e[32m%s\n\e[m" ">>  OK!"
 fi
 
-rm -f a.out leaksout
+rm -f $DIR/a.out leaksout
 
-tests=(
+
+errors=(
+	"a |"
+	"a ||"
+	"a | |"
 	"cat >"
 	"cat >> >"
+
+	### never support
+	# "cat < ;"
+	# "echo a;;"
+	# "echo a;; ;"
 )
 
-echo "=== error_test ==="
+echo "--- error_test ---"
 gcc -g $INCLUDES \
+-o $DIR/a.out \
 "$DIR/for_error_test.c" \
 $(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
 $(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
 $SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
 
-for i in ${!tests[@]};
+for i in ${!errors[@]};
 do
-	./a.out "${tests[$i]}"
+	echo "${errors[$i]}" | bash
+	$DIR/a.out "${errors[$i]}"
 	AOUT=$?
-	if [ $AOUT -ne 0 ]; then
+	if [ $AOUT -eq 0 ]; then
 		EXIT_CODE=1
 		printf "\e[31m%s\n\e[m" ">>  KO!"
 	else

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -26,9 +26,6 @@ else
 	printf "\e[32m%s\n\e[m" ">>  OK!"
 fi
 
-rm -f $DIR/a.out leaksout
-
-
 echo "--- error_test ---"
 gcc -g $INCLUDES \
 -o $DIR/a.out \
@@ -47,6 +44,7 @@ else
 	printf "\e[32m%s\n\e[m" ">>  OK!"
 fi
 
-rm -f a.out leaksout
+rm -f $DIR/a.out leaksout
+rm -rf $DIR/a.out.dSYM
 
 exit $EXIT_CODE

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -29,19 +29,6 @@ fi
 rm -f $DIR/a.out leaksout
 
 
-errors=(
-	"a |"
-	"a ||"
-	"a | |"
-	"cat >"
-	"cat >> >"
-
-	### never support
-	# "cat < ;"
-	# "echo a;;"
-	# "echo a;; ;"
-)
-
 echo "--- error_test ---"
 gcc -g $INCLUDES \
 -o $DIR/a.out \
@@ -50,18 +37,15 @@ $(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
 $(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
 $SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
 
-for i in ${!errors[@]};
-do
-	echo "${errors[$i]}" | bash
-	$DIR/a.out "${errors[$i]}"
-	AOUT=$?
-	if [ $AOUT -eq 0 ]; then
-		EXIT_CODE=1
-		printf "\e[31m%s\n\e[m" ">>  KO!"
-	else
-		printf "\e[32m%s\n\e[m" ">>  OK!"
-	fi
-done
+$DIR/a.out
+AOUT=$?
+
+if [ $AOUT -ne 0 ]; then
+	EXIT_CODE=1
+	printf "\e[31m%s\n\e[m" ">>  KO!"
+else
+	printf "\e[32m%s\n\e[m" ">>  OK!"
+fi
 
 rm -f a.out leaksout
 

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -9,18 +9,40 @@ test_res_print() {
 DIR="$(dirname "$0")"
 
 EXIT_CODE=0
-for path in $(find $DIR -type f -name "*.c");
+gcc -g $INCLUDES \
+$DIR/test.c \
+$(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
+$(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
+$SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
+
+./a.out
+AOUT=$?
+
+if [ $AOUT -ne 0 ]; then
+	EXIT_CODE=1
+	printf "\e[31m%s\n\e[m" ">>  KO!"
+else
+	printf "\e[32m%s\n\e[m" ">>  OK!"
+fi
+
+rm -f a.out leaksout
+
+tests=(
+	"cat >"
+	"cat >> >"
+)
+
+echo "=== error_test ==="
+gcc -g $INCLUDES \
+"$DIR/for_error_test.c" \
+$(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
+$(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
+$SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
+
+for i in ${!tests[@]};
 do
-	echo $path
-	gcc -g $INCLUDES \
-	"$path" \
-	$(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
-	$(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
-	$SHARED_LIB $LIBS -lft -lex -lreadline
-
-	./a.out
+	./a.out "${tests[$i]}"
 	AOUT=$?
-
 	if [ $AOUT -ne 0 ]; then
 		EXIT_CODE=1
 		printf "\e[31m%s\n\e[m" ">>  KO!"
@@ -30,3 +52,5 @@ do
 done
 
 rm -f a.out leaksout
+
+exit $EXIT_CODE

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -39,7 +39,7 @@ AOUT=$?
 
 diff $DIR/out $DIR/error_case_expect > /dev/null
 
-if [ $? -ne 0 ] && [ $AOUT -ne 0 ]; then
+if [ $? -ne 0 ] || [ $AOUT -ne 0 ]; then
 	EXIT_CODE=1
 	diff -y $DIR/out $DIR/error_case_expect
 	printf "\e[31m%s\n\e[m" ">>  KO!"

--- a/tests/unit-test/function-parse/test.sh
+++ b/tests/unit-test/function-parse/test.sh
@@ -34,17 +34,20 @@ $(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
 $(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
 $SHARED_LIB $LIBS -lft -lex -lreadline || exit 1
 
-$DIR/a.out
+$DIR/a.out 2> $DIR/out
 AOUT=$?
 
-if [ $AOUT -ne 0 ]; then
+diff $DIR/out $DIR/error_case_expect > /dev/null
+
+if [ $? -ne 0 ] && [ $AOUT -ne 0 ]; then
 	EXIT_CODE=1
+	diff -y $DIR/out $DIR/error_case_expect
 	printf "\e[31m%s\n\e[m" ">>  KO!"
 else
 	printf "\e[32m%s\n\e[m" ">>  OK!"
 fi
 
-rm -f $DIR/a.out leaksout
+rm -f $DIR/a.out leaksout $DIR/out
 rm -rf $DIR/a.out.dSYM
 
 exit $EXIT_CODE


### PR DESCRIPTION
## 概要

* kohkubo/minishell#168 
* テストにそぐわない出力の修正

## やったこと詳細

* トークンの単方向リストを入力にして、その標準エラー出力と返り値をチェックするテストを追加。
* 終了ステータスを確認するように。
* テストにそぐわないエラー出力を修正。

### 「テストにそぐわないエラー出力の修正」について
`echo a > >>`の場合

#### これまでの実装
* `echo a`の次に`>`があることを確認した後、"確認箇所"を1つ進めて`TOKEN`があるかを確認していた。
* `TOKEN`でなかった場合"確認箇所"を`>`のある位置に戻して`<`があるかのチェック、`>>`があるかのチェック…と別のリダイレクトのチェックに移っていた。
* 最終的にどの構文にも当てはまらなかった場合、最後に確認していた"確認箇所"を`syntax error near unexpected token`として出力していた。

#### 原因
* `>`の後ろにエラーがあった際、**"確認箇所"を`>`に戻してしまうのでsyntax errorとしても`>`が出力されてしまった**

#### 修正
* `echo a`の次に`>`があることを確認した後`TOKEN`が来ない場合、他の構文である可能性は無くなりエラーが確定するので、他の構文かどうかのチェックは必要がない。
* エラーが確定した際には全てのチェックを終了し、大本の関数まで戻りたいので`has_error`フラグをもたせることで解決した。
* （throwのある言語ならそれを使うと良い）

## やらないこと（あれば）


## 動作確認・テスト

```
make test_unit TARGET=function-parse
```

## その他

