### PR TITLE
Refactor: leaksの余分な表示を削除

### DIFF
--- a/tests/sharedlib.c
+++ b/tests/sharedlib.c
@@ -2,13 +2,14 @@
 #include <stdio.h>
 #include <unistd.h>
 
-__attribute__((destructor))
+void	destructor(void)__attribute__((destructor));
+
 void	destructor(void)
 {
 	int		status;
 	char	buf[50];
 
-	snprintf(buf, 50, "leaks %d &> leaksout", getpid());
+	snprintf(buf, 50, "leaks -q %d &> leaksout", getpid());
 	status = system(buf);
 	if (status)
 	{


### PR DESCRIPTION
## 概要

* leaksの余分な表示を削除した

## やったこと詳細

* leaksは`-q`オプションを使用するように変更
* ついでにnorm対応
  - normエラー箇所を赤く表示する拡張機能を使っていると見辛いので

## やらないこと（あれば）

* なし

## 動作確認・テスト

* どこかでリーク作ってテストしてみてください。

## その他

* leaksのオプションは結構豊富で、backtrace表示とか便利そうなのがありますが、だいたい機能しませんでした。
