### PR TITLE
exportでvalueがNULLのとき、既存の環境変数が上書きされるbug

### DIFF
--- a/srcs/env/env.c
+++ b/srcs/env/env.c
@@ -17,7 +17,8 @@ void	store_shellenv(char **arr, t_hash_table *table)
 		}
 		else
 		{
-			hash_setstr(table, arr[i], NULL);
+			if (hash_getstr(table, arr[i]) == NULL)
+				hash_setstr(table, arr[i], NULL);
 		}
 		i++;
 	}

--- a/tests/issue/export/export_null_value_case.txt
+++ b/tests/issue/export/export_null_value_case.txt
@@ -1,0 +1,2 @@
+export USER
+export


### PR DESCRIPTION
## 概要

* このプルリクの概要

valueがNULLのときで、既存のkeyがある場合は変数を上書きしないように変更

* 関連するIssueやプルリクエスト

kohkubo/minishell#199 

## やらないこと（あれば）

なし

## 動作確認・テスト

* どのように動作確認・テストを行うか？
* コマンドなど

```
make test_issue TARGET="export"
```

