### PR TITLE
add: minishell pexit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ src =\
 	./built-in/ft_unset.c \
 	./built-in/ft_pwd.c \
 	./main.c \
+	./error.c \
 	./env/env.c \
 	./parse/parse-v2.c \
 	./parse/astree.c \

--- a/includes/error.h
+++ b/includes/error.h
@@ -1,0 +1,8 @@
+#ifndef ERROR_H
+# define ERROR_H
+
+void	minishell_pexit(char *message);
+int		catch_err(int status, char *title);
+void	*catch_nul(void *ptr, char *title);
+
+#endif

--- a/srcs/error.c
+++ b/srcs/error.c
@@ -1,0 +1,26 @@
+#include "error.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "libft.h"
+
+void	minishell_pexit(char *message)
+{
+	ft_putstr_fd("minishell: ", 2);
+	perror(message);
+	exit(1);
+}
+
+int	catch_err(int status, char *title)
+{
+	if (status == -1)
+		minishell_pexit(title);
+	return (status);
+}
+
+void	*catch_nul(void *ptr, char *title)
+{
+	if (ptr == NULL)
+		minishell_pexit(title);
+	return (ptr);
+}

--- a/srcs/execute/exec_cmdline.c
+++ b/srcs/execute/exec_cmdline.c
@@ -1,9 +1,10 @@
 #include "exec.h"
 
-#include "astree.h"
+#include <unistd.h>
 #include <sys/wait.h>
 #include <errno.h>
-#include "libex.h"
+#include "astree.h"
+#include "error.h"
 
 enum e_mean
 {
@@ -27,7 +28,7 @@ void	execute_cmdline(t_astree *tree, int *status)
 
 	pid[_] = 0;
 	pid[LAST] = -1;
-	pid[STDIN_BACKUP] = catch_error(dup(STDIN_FILENO), "dup");
+	pid[STDIN_BACKUP] = catch_err(dup(STDIN_FILENO), "dup");
 	execute_job(tree, status, &pid[LAST]);
 	dup2(pid[STDIN_BACKUP], STDIN_FILENO);
 	while (pid[_] >= 0)
@@ -37,5 +38,5 @@ void	execute_cmdline(t_astree *tree, int *status)
 			*status = child_status;
 	}
 	if (errno != ECHILD)
-		pexit("minishell");
+		minishell_pexit("");
 }

--- a/srcs/execute/exec_job.c
+++ b/srcs/execute/exec_job.c
@@ -2,15 +2,15 @@
 
 #include "astree.h"
 #include "libft.h"
-#include "libex.h"
+#include "error.h"
 
 #define CHILD	(0)
 
 void	connect_pipe(int pipefd[2], int fd)
 {
-	catch_error(dup2(pipefd[fd], fd), "dup2");
-	catch_error(close(pipefd[0]), "close");
-	catch_error(close(pipefd[1]), "close");
+	catch_err(dup2(pipefd[fd], fd), "dup2");
+	catch_err(close(pipefd[0]), "close");
+	catch_err(close(pipefd[1]), "close");
 }
 
 /*
@@ -23,8 +23,8 @@ void	execute_job(t_astree *tree, int *status, pid_t *pid)
 
 	if (tree->type & NODE_PIPE)
 	{
-		catch_error(pipe(pipefd), "pipe");
-		*pid = catch_error(fork(), "fork");
+		catch_err(pipe(pipefd), "pipe");
+		*pid = catch_err(fork(), "fork");
 		if (*pid == CHILD)
 		{
 			connect_pipe(pipefd, STDOUT_FILENO);
@@ -37,7 +37,7 @@ void	execute_job(t_astree *tree, int *status, pid_t *pid)
 	{
 		if (*pid == -1 && is_builtin(tree))
 			return ((void)(*status = execute_cmd(tree)));
-		*pid = catch_error(fork(), "fork");
+		*pid = catch_err(fork(), "fork");
 		if (*pid == CHILD)
 			exit(execute_cmd(tree));
 	}

--- a/srcs/execute/exec_simplecmd.c
+++ b/srcs/execute/exec_simplecmd.c
@@ -3,7 +3,7 @@
 #include "shell.h"
 #include "astree.h"
 #include "libft.h"
-#include "libex.h"
+#include "error.h"
 
 char	**get_fullpath(const char *path, char *cmd)
 {
@@ -12,15 +12,15 @@ char	**get_fullpath(const char *path, char *cmd)
 
 	if (path == NULL || cmd == NULL)
 		return (NULL);
-	paths = catch_null(ft_split(path, ':'), "split");
+	paths = catch_nul(ft_split(path, ':'), "split");
 	i = 0;
 	while (paths[i])
 	{
 		if (paths[i][ft_strlen(paths[i]) - 1] != '/')
 			free_set((void **)&paths[i],
-				catch_null(ft_strjoin(paths[i], "/"), "ft_strjoin"));
+				catch_nul(ft_strjoin(paths[i], "/"), "ft_strjoin"));
 		free_set((void **)&paths[i],
-			catch_null(ft_strjoin(paths[i], cmd), "ft_strjoin"));
+			catch_nul(ft_strjoin(paths[i], cmd), "ft_strjoin"));
 		i++;
 	}
 	return (paths);
@@ -38,7 +38,7 @@ int	exec_with_path(char *cmd, char **args, char **envp)
 	while (fullpaths && fullpaths[i])
 	{
 		if (access(fullpaths[i], X_OK) == 0)
-			res = catch_error(execve(fullpaths[i], args, envp), cmd);
+			res = catch_err(execve(fullpaths[i], args, envp), cmd);
 		i++;
 	}
 	if (res < 0 && errno == ENOENT)
@@ -95,7 +95,7 @@ int	execute_simplecmd(t_astree *tree)
 		if (!ft_strchr(tree->data, '/'))
 			res = exec_with_path(tree->data, args, envp);
 		else if (access(tree->data, X_OK) == 0)
-			res = catch_error(execve(tree->data, args, envp), tree->data);
+			res = catch_err(execve(tree->data, args, envp), tree->data);
 		else if (errno == ENOENT)
 			res = minishell_perror(tree->data, 127);
 		else if (errno == EACCES)

--- a/tests/unit-test/execute/test.sh
+++ b/tests/unit-test/execute/test.sh
@@ -4,6 +4,7 @@ EXIT_CODE=0
 gcc -g $INCLUDES \
 -o "$DIR/a.out" \
 "$DIR/test.c" \
+"$REPO_ROOT/srcs/error.c" \
 $(find $REPO_ROOT/srcs/lex/ -type f -name "*.c") \
 $(find $REPO_ROOT/srcs/parse/ -type f -name "*.c" -not -name 'parse.c') \
 $(find $REPO_ROOT/srcs/execute/ -type f -name "*.c") \


### PR DESCRIPTION
## 概要

* fix #218 

## やったこと詳細

* pexitに"minishell: "を出力させる
  * open()に失敗した際などに"minishell: filename: ...."とする必要があるため

* minishell_pexitを使った関数への置換

* 複数libにまたがって依存されているpexitはそのままに、新しくminishell_pexitを作成

## やらないこと（あれば）

* 既存のpexitの引数を追加すること
* pexitにわたす文字列に"minishell: "を結合すること
  * どちらも冗長。

