### PR TITLE
空行が来ても終了しない

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -16,7 +16,7 @@ int	main(void)
 		if (input == NULL || ft_strlen(input) == 0)
 		{
 			free_set((void **)&input, NULL);
-			break ;
+			continue ;
 		}
 		add_history(input);
 		lex = NULL;


### PR DESCRIPTION
## 概要

* 空行が来てもminishellが終了しないように変更

## やったこと詳細

* break -> continue

## 動作確認・テスト

* makeして空行を入れてください

## その他

* readlineがNULLを返したときにもシェルを続行する形になってますが、それで大丈夫ですか？
